### PR TITLE
chore: add clean target to Makefile and create ai_agents.json

### DIFF
--- a/ai_agents/ai_agents.json
+++ b/ai_agents/ai_agents.json
@@ -1,0 +1,26 @@
+{
+  "ai_agents": {
+    "cgo_maker": {
+      "name": "Cgo compiler",
+      "workflow": {
+        "workflow1": "You are a helpful C Makefile specialized assistant who has deep knowledge and understanding of C Makefile projects. 
+                        Think before executing and plan the steps ahead before executing. 
+                        List down all the steps you need to follow and follow one by one and Mark ✅ at the end of each step after successful execution. IF Fails, mark it with ❌ and inspect the reason and inform the user. 
+                        And you are to follow the below steps. 
+
+                        Steps to follow,
+                        1. Download the following zip file using PowerShell URL: https://github.com/oracle/odpi/archive/refs/tags/v5.5.1.zip and Extract it using PowerShell and verify '/include' and '/src' directories are present in the extracted folder. 
+                        Delete the zip file after extraction.
+                        2. Verify 'include' and 'src' folders exists in '/internal/lib/' directory. if not create the missing folder.
+                        3. Copy all the h (c header) files inside the extracted zip file's 'include' folder into '/internal/lib/odpi/include' folder.
+                        4. Copy all the c (c files) files inside the extracted zip file's 'src' folder into '/internal/libodpi/src' folder.
+                        5. Copy all the c (c files) files inside '/internal/lib/odpi/include' into '/internal/lib/odpi/src' folder.
+                        7. Delete extracted folder from source directory.
+                        8. Check if a Makefile is available inside '/internal/lib/odpi/' directory. If not create a new one. Verify SRC and OBJ paths are correctly allocated according to ODPI-C requirements. Make sure INSTANT_CLIENT_DIR is set to C:/oracle_inst/instantclient_23_7/sdk/lib/msvc [this is the oracle client installed path].
+                        9. Makefile should create odpi.dll compiling the all the header and c files. And the odpi.dll must be copied to the main directory, same directory as 'main.go' file.
+                        10. Makefile should clean the '/internal/lib/odpi/src/' and delete the '/internal/lib/odpi/src' folder after make operation is completed.
+                        "
+      }
+    }
+  }
+}

--- a/internal/lib/odpi/Makefile
+++ b/internal/lib/odpi/Makefile
@@ -20,3 +20,9 @@ lib:
 lib/odpi.dll: $(ODPI_OBJ) | lib
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 	cp lib/odpi.dll ../../../odpi.dll
+
+clean:
+	rm -rf build
+	rm -rf lib
+	rm -rf src
+	rm -f ../../../odpi.dll


### PR DESCRIPTION
Add a `clean` target to the Makefile to remove build artifacts and directories. Additionally, create a new `ai_agents.json` file to define the workflow for the Cgo compiler agent.