### PR TITLE
fix(database): correct database connection string formatting

### DIFF
--- a/internal/utils/database.go
+++ b/internal/utils/database.go
@@ -27,7 +27,7 @@ func NewDBConnection() *Database {
 	// Set connection parameters
 	username := dbConfigs.Username
 	password := dbConfigs.Password
-	connectionString := fmt.Sprintf("%s:%s/%s", dbConfigs.Database, dbConfigs.Port, dbConfigs.Host)
+	connectionString := fmt.Sprintf("%s:%s/%s", dbConfigs.Database, fmt.Sprint(dbConfigs.Port), dbConfigs.Host)
 
 	// Set Context for the connection
 	context := SetContext()


### PR DESCRIPTION
The port value was being directly interpolated into the string without conversion, which could cause issues with non-string port values. Using fmt.Sprint ensures proper string conversion of the port number.