### PR TITLE
Fix build failure and update documentation for OmniView

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ make odpi
 
 Hexagonal (Ports and Adapters) architecture:
 
-```
+```text
 ┌─────────────────────────────────────────┐
 │  cmd/omniview/main.go (Bootstrap)       │
 └─────────────────────────────────────────┘

--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	// Load configuration (may prompt user via stdin if first run)
 	dbSettingsRepo := boltdb.NewDatabaseSettingsRepository(boltAdapter)
-	cfgLoader := config.NewConfigLoader(dbSettingsRepo)
+	cfgLoader := config.NewConfigLoader(dbSettingsRepo, boltAdapter)
 	appConfig, err := cfgLoader.LoadClientConfigurations()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)

--- a/docs/SUBSCRIBER_ISOLATION_SOLUTION.md
+++ b/docs/SUBSCRIBER_ISOLATION_SOLUTION.md
@@ -164,7 +164,7 @@ BEGIN
 
     -- Set consumer for targeted delivery
     IF v_consumer_name IS NOT NULL THEN
-        message_properties.consumer_name := v_consumer_name;
+        message_properties.recipient_list(1) := SYS.AQ$_AGENT(v_consumer_name, NULL, NULL);
     END IF;
 
     -- Build message
@@ -425,7 +425,7 @@ BEGIN
 
     -- Set consumer for targeted delivery
     IF v_consumer_name IS NOT NULL THEN
-        message_properties.consumer_name := v_consumer_name;
+        message_properties.recipient_list(1) := SYS.AQ$_AGENT(v_consumer_name, NULL, NULL);
     END IF;
 
     -- Build comprehensive message
@@ -655,14 +655,10 @@ CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
         END IF;
 
         -- Priority 3: Session binding
-        BEGIN
-            v_subscriber := Get_Bound_Subscriber();
-            IF v_subscriber IS NOT NULL THEN
-                RETURN v_subscriber;
-            END IF;
-        EXCEPTION
-            WHEN OTHERS THEN NULL;
-        END;
+        v_subscriber := Get_Bound_Subscriber();
+        IF v_subscriber IS NOT NULL THEN
+            RETURN v_subscriber;
+        END IF;
 
         -- Fallback: Broadcast (return NULL)
         RETURN NULL;

--- a/docs/TUI_MIGRATION_SPEC.md
+++ b/docs/TUI_MIGRATION_SPEC.md
@@ -1453,7 +1453,7 @@ func main() {
 
     // Load configuration (may prompt user via stdin if first run)
     dbSettingsRepo := boltdb.NewDatabaseSettingsRepository(boltAdapter)
-    cfgLoader := config.NewConfigLoader(dbSettingsRepo)
+    cfgLoader := config.NewConfigLoader(dbSettingsRepo, boltAdapter)
     appConfig, err := cfgLoader.LoadClientConfigurations()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Failed to load config: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ toolchain go1.24.4
 require (
 	charm.land/bubbletea/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.0
+	charm.land/bubbles/v2 v2.0.0
 	github.com/google/uuid v1.6.0
 	go.etcd.io/bbolt v1.4.3
 )
 
 require (
-	charm.land/bubbles/v2 v2.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect


### PR DESCRIPTION
Fixed a build error in the bootstrap logic where `config.NewConfigLoader` was missing a required argument. Also updated the project documentation for consistency and followed instructions to resolve a markdownlint warning. Specifically:
- Corrected the `NewConfigLoader` call in `cmd/omniview/main.go` and its documentation in `docs/TUI_MIGRATION_SPEC.md`.
- Added the `text` tag to the ASCII diagram in `CLAUDE.md`.
- Updated the Oracle AQ enqueue logic in `docs/SUBSCRIBER_ISOLATION_SOLUTION.md` to use the `recipient_list` pattern for targeted delivery.
- Refined the exception handling in the same file to expose errors.
- Synchronized `go.mod` with the direct dependency requirements.

---
*PR created automatically by Jules for task [5691220779692904267](https://jules.google.com/task/5691220779692904267) started by @BasuruK*