### PR TITLE
fix: enable clipboard paste in database forms

### DIFF
--- a/internal/adapter/ui/add_database_form.go
+++ b/internal/adapter/ui/add_database_form.go
@@ -128,11 +128,19 @@ func (f *AddDatabaseForm) validate() string {
 // ─────────────────────────
 
 // Update: handles keyboard input for the add database form including navigation, character input, and form submission.
-func (f AddDatabaseForm) Update(msg tea.KeyPressMsg) (AddDatabaseForm, tea.Cmd) {
+func (f AddDatabaseForm) Update(msg tea.Msg) (AddDatabaseForm, tea.Cmd) {
 	if f.submitted || f.cancelled {
 		return f, nil
 	}
 
+	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		if f.cursor < formFieldCount {
+			f.fields[f.cursor].Value += msg.String()
+			f.errMsg = ""
+		}
+		return f, nil
+	case tea.KeyPressMsg:
 	key := msg.String()
 
 	switch key {
@@ -205,6 +213,8 @@ func (f AddDatabaseForm) Update(msg tea.KeyPressMsg) (AddDatabaseForm, tea.Cmd) 
 		f.errMsg = ""
 	}
 
+	return f, nil
+	}
 	return f, nil
 }
 

--- a/internal/adapter/ui/check_onboarding.js
+++ b/internal/adapter/ui/check_onboarding.js
@@ -1,0 +1,3 @@
+const fs = require('fs');
+let file = fs.readFileSync('onboarding.go', 'utf8');
+console.log(file.includes('AddDatabaseForm'));

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -110,8 +110,9 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 				m.cancel()
 				return m, tea.Quit
 			}
-			var cmd tea.Cmd
-			m.dbSettings.addForm, cmd = m.dbSettings.addForm.Update(keyMsg)
+		}
+		var cmd tea.Cmd
+		m.dbSettings.addForm, cmd = m.dbSettings.addForm.Update(msg)
 			if m.dbSettings.addForm.IsCancelled() {
 				m.dbSettings.showAddForm = false
 				return m, nil
@@ -121,8 +122,7 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 				return m, m.saveAddFormCmd()
 			}
 			return m, cmd
-		}
-		return m, nil
+		// return m, nil
 	}
 
 	switch msg := msg.(type) {

--- a/internal/adapter/ui/onboarding.go
+++ b/internal/adapter/ui/onboarding.go
@@ -36,6 +36,14 @@ var onboardingFields = []onboardingField{
 func (m *Model) updateOnboarding(msg tea.Msg) (*Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
+	case tea.PasteMsg:
+		if !m.onboarding.submitted {
+			val := m.onboarding.fieldValue(m.onboarding.step)
+			*val += msg.String()
+			m.onboarding.errMsg = ""
+		}
+		return m, nil
+
 	case tea.KeyPressMsg:
 		return m.handleOnboardingKey(msg)
 

--- a/internal/adapter/ui/patch_add_form.js
+++ b/internal/adapter/ui/patch_add_form.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+let file = fs.readFileSync('add_database_form.go', 'utf8');
+
+file = file.replace(
+    /func \(f AddDatabaseForm\) Update\(msg tea\.KeyPressMsg\) \(AddDatabaseForm, tea\.Cmd\) \{/,
+    `func (f AddDatabaseForm) Update(msg tea.Msg) (AddDatabaseForm, tea.Cmd) {
+	if f.submitted || f.cancelled {
+		return f, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		if f.cursor < formFieldCount {
+			f.fields[f.cursor].Value += msg.String()
+			f.errMsg = ""
+		}
+		return f, nil
+	case tea.KeyPressMsg:`
+);
+
+file = file.replace(
+    /	if f\.submitted \|\| f\.cancelled \{\n		return f, nil\n	\}\n\n	key := msg\.String\(\)/,
+    `	key := msg.String()`
+);
+
+file = file.replace(
+    /	return f, nil\n\}/,
+    `	return f, nil
+	}
+	return f, nil
+}`
+);
+
+fs.writeFileSync('add_database_form.go', file);

--- a/internal/adapter/ui/patch_db_settings.js
+++ b/internal/adapter/ui/patch_db_settings.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+let file = fs.readFileSync('database_settings.go', 'utf8');
+
+file = file.replace(
+    /		if keyMsg, ok := msg\.\(tea\.KeyPressMsg\); ok \{\n			if keyMsg\.String\(\) == "ctrl\+c" \{\n				m\.cancel\(\)\n				return m, tea\.Quit\n			\}\n			var cmd tea\.Cmd\n			m\.dbSettings\.addForm, cmd = m\.dbSettings\.addForm\.Update\(keyMsg\)/,
+    `		if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+			if keyMsg.String() == "ctrl+c" {
+				m.cancel()
+				return m, tea.Quit
+			}
+		}
+		var cmd tea.Cmd
+		m.dbSettings.addForm, cmd = m.dbSettings.addForm.Update(msg)`
+);
+
+fs.writeFileSync('database_settings.go', file);

--- a/internal/adapter/ui/patch_db_settings3.js
+++ b/internal/adapter/ui/patch_db_settings3.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+let file = fs.readFileSync('database_settings.go', 'utf8');
+
+file = file.replace(
+    /			return m, cmd\n		\}\n		return m, nil/,
+    `			return m, cmd
+		// return m, nil`
+);
+
+fs.writeFileSync('database_settings.go', file);

--- a/internal/adapter/ui/patch_onboarding.js
+++ b/internal/adapter/ui/patch_onboarding.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+let file = fs.readFileSync('onboarding.go', 'utf8');
+
+file = file.replace(
+    /	case tea\.KeyPressMsg:\n		return m\.handleOnboardingKey\(msg\)/,
+    `	case tea.PasteMsg:
+		if !m.onboarding.submitted {
+			val := m.onboarding.fieldValue(m.onboarding.step)
+			*val += msg.String()
+			m.onboarding.errMsg = ""
+		}
+		return m, nil
+
+	case tea.KeyPressMsg:
+		return m.handleOnboardingKey(msg)`
+);
+
+fs.writeFileSync('onboarding.go', file);


### PR DESCRIPTION
Fixes #52

Added support for `tea.PasteMsg` in the `onboarding` screen and `AddDatabaseForm` components. This resolves the bug where users were unable to paste clipboard values (e.g. database URLs, passwords) into the TUI input fields, as Bubble Tea v2 intercepts bracketed paste and sends it as `tea.PasteMsg` rather than keyboard keystrokes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clipboard paste support to form input fields in the database addition and onboarding workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->