### PR TITLE
Database defaults after database switch

### DIFF
--- a/internal/adapter/storage/boltdb/database_settings_repository.go
+++ b/internal/adapter/storage/boltdb/database_settings_repository.go
@@ -72,6 +72,46 @@ func (dsr *DatabaseSettingsRepository) Save(ctx context.Context, settings domain
 	})
 }
 
+// SwitchDefault stores the previous and new default settings in a single transaction.
+func (dsr *DatabaseSettingsRepository) SwitchDefault(ctx context.Context, previousDefault *domain.DatabaseSettings, newDefault domain.DatabaseSettings) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if dsr == nil || dsr.adapter == nil || dsr.adapter.db == nil {
+		return ErrAdapterNotInitialized
+	}
+
+	return dsr.adapter.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(DatabaseConfigBucket))
+		if b == nil {
+			return fmt.Errorf("bucket %s not found", DatabaseConfigBucket)
+		}
+
+		if previousDefault != nil && previousDefault.StorageKey() != newDefault.StorageKey() {
+			previousJSON, err := json.Marshal(previousDefault)
+			if err != nil {
+				return fmt.Errorf("failed to marshal previous default database settings: %w", err)
+			}
+			if err := b.Put([]byte(previousDefault.StorageKey()), previousJSON); err != nil {
+				return fmt.Errorf("failed to save previous default database settings: %w", err)
+			}
+		}
+
+		newJSON, err := json.Marshal(&newDefault)
+		if err != nil {
+			return fmt.Errorf("failed to marshal new default database settings: %w", err)
+		}
+		if err := b.Put([]byte(newDefault.StorageKey()), newJSON); err != nil {
+			return fmt.Errorf("failed to save new default database settings: %w", err)
+		}
+		if err := b.Put([]byte(DefaultDatabaseConfigKey), []byte(newDefault.StorageKey())); err != nil {
+			return fmt.Errorf("failed to save default database settings key: %w", err)
+		}
+
+		return nil
+	})
+}
+
 // GetByID retrieves database settings by ID
 func (dsr *DatabaseSettingsRepository) GetByID(ctx context.Context, id string) (*domain.DatabaseSettings, error) {
 	// Check for context cancellation before proceeding

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -304,6 +304,18 @@ func (m *Model) handleSettingsSetAsMain(selectedDb domain.DatabaseSettings) (*Mo
 	m.appConfig.SetAsDefault()
 	m.dbAdapter = newAdapter
 
+	for index := range m.dbSettings.databases {
+		if m.dbSettings.databases[index].ID() == selectedDb.ID() {
+			m.dbSettings.databases[index].SetAsDefault()
+			break
+		}
+	}
+
+	settingsRepo := boltdb.NewDatabaseSettingsRepository(m.boltAdapter)
+	if err := settingsRepo.Save(m.ctx, *m.appConfig); err != nil {
+		log.Printf("[UI] Failed to persist default database flag for %s: %v", selectedDb.DatabaseID(), err)
+	}
+
 	// Reset dependent services to be reinit with new adapter
 	m.permissionService = nil
 	m.tracerService = nil

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -272,7 +272,65 @@ func (m *Model) markActiveConnectionPermissionsValidated() error {
 	return nil
 }
 
-// handleSettingsSetAsMain updates the active database configuration and reinitializes dependent services.
+// databaseSettingsWithDefaultState: returns a copy of the given settings with the default flag set as specified, preserving permission validation state.
+func databaseSettingsWithDefaultState(settings domain.DatabaseSettings, isDefault bool) (domain.DatabaseSettings, error) {
+	updated, err := domain.NewDatabaseSettings(
+		settings.DatabaseID(),
+		settings.Database(),
+		settings.Host(),
+		settings.Port(),
+		settings.Username(),
+		settings.Password(),
+	)
+	if err != nil {
+		return domain.DatabaseSettings{}, fmt.Errorf("clone database settings %q: %w", settings.DatabaseID(), err)
+	}
+	if settings.PermissionsValidated() {
+		updated.MarkPermissionsValidated()
+	}
+	if isDefault {
+		updated.SetAsDefault()
+	}
+	return *updated, nil
+}
+
+// syncDatabaseSettingsDefaults: updates the default state of the database settings in the UI list based on the selected database.
+func (m *Model) syncDatabaseSettingsDefaults(selectedDb domain.DatabaseSettings) {
+	for index := range m.dbSettings.databases {
+		updated, err := databaseSettingsWithDefaultState(m.dbSettings.databases[index], m.dbSettings.databases[index].ID() == selectedDb.ID())
+		if err != nil {
+			log.Printf("[UI] Failed to sync database default state for %s: %v", m.dbSettings.databases[index].DatabaseID(), err)
+			continue
+		}
+		m.dbSettings.databases[index] = updated
+	}
+}
+
+// persistDefaultDatabaseSelection: updates the default database selection in the repository.
+func (m *Model) persistDefaultDatabaseSelection(previousDefault *domain.DatabaseSettings, selectedDb domain.DatabaseSettings) error {
+	if m.boltAdapter == nil {
+		return nil
+	}
+
+	settingsRepo := boltdb.NewDatabaseSettingsRepository(m.boltAdapter)
+	var updatedPrevious *domain.DatabaseSettings
+
+	if previousDefault != nil && previousDefault.ID() != selectedDb.ID() && previousDefault.IsDefault() {
+		clearedPrevious, err := databaseSettingsWithDefaultState(*previousDefault, false)
+		if err != nil {
+			return fmt.Errorf("clear previous default %q: %w", previousDefault.DatabaseID(), err)
+		}
+		updatedPrevious = &clearedPrevious
+	}
+
+	if err := settingsRepo.SwitchDefault(m.ctx, updatedPrevious, selectedDb); err != nil {
+		return fmt.Errorf("persist default database selection %q: %w", selectedDb.DatabaseID(), err)
+	}
+
+	return nil
+}
+
+// handleSettingsSetAsMain: updates the active database configuration and reinitializes dependent services.
 func (m *Model) handleSettingsSetAsMain(selectedDb domain.DatabaseSettings) (*Model, tea.Cmd) {
 	newAdapter, err := m.dbFactory(&selectedDb)
 	if err != nil {
@@ -290,6 +348,15 @@ func (m *Model) handleSettingsSetAsMain(selectedDb domain.DatabaseSettings) (*Mo
 		log.Printf("[UI] Failed to close validated database adapter for %s: %v", selectedDb.DatabaseID(), err)
 	}
 
+	previousConfig := m.appConfig
+	updatedSelected, err := databaseSettingsWithDefaultState(selectedDb, true)
+	if err != nil {
+		return m.showDatabaseSwitchError(fmt.Errorf("failed to prepare database %q as default: %w", selectedDb.DatabaseID(), err))
+	}
+	if err := m.persistDefaultDatabaseSelection(previousConfig, updatedSelected); err != nil {
+		return m.showDatabaseSwitchError(fmt.Errorf("failed to persist database %q as default: %w", selectedDb.DatabaseID(), err))
+	}
+
 	m.resetConnectionEventStream()
 	if m.tracerService != nil {
 		m.tracerService.CancelConnectionListener()
@@ -300,21 +367,9 @@ func (m *Model) handleSettingsSetAsMain(selectedDb domain.DatabaseSettings) (*Mo
 		}
 	}
 
-	m.appConfig = &selectedDb
-	m.appConfig.SetAsDefault()
+	m.appConfig = &updatedSelected
 	m.dbAdapter = newAdapter
-
-	for index := range m.dbSettings.databases {
-		if m.dbSettings.databases[index].ID() == selectedDb.ID() {
-			m.dbSettings.databases[index].SetAsDefault()
-			break
-		}
-	}
-
-	settingsRepo := boltdb.NewDatabaseSettingsRepository(m.boltAdapter)
-	if err := settingsRepo.Save(m.ctx, *m.appConfig); err != nil {
-		log.Printf("[UI] Failed to persist default database flag for %s: %v", selectedDb.DatabaseID(), err)
-	}
+	m.syncDatabaseSettingsDefaults(*m.appConfig)
 
 	// Reset dependent services to be reinit with new adapter
 	m.permissionService = nil

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -301,6 +301,7 @@ func (m *Model) handleSettingsSetAsMain(selectedDb domain.DatabaseSettings) (*Mo
 	}
 
 	m.appConfig = &selectedDb
+	m.appConfig.SetAsDefault()
 	m.dbAdapter = newAdapter
 
 	// Reset dependent services to be reinit with new adapter

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"OmniView/internal/adapter/storage/boltdb"
 	"OmniView/internal/core/domain"
 	"OmniView/internal/core/ports"
 	"OmniView/internal/service/tracer"
@@ -177,6 +178,25 @@ func mustNewTracerService(t *testing.T, db ports.DatabaseRepository, eventChanne
 	}
 
 	return service
+}
+
+func newTestBoltAdapter(t *testing.T) *boltdb.BoltAdapter {
+	t.Helper()
+
+	dbPath := t.TempDir() + "/test.bolt"
+	adapter, err := boltdb.NewBoltAdapter(dbPath)
+	if err != nil {
+		t.Fatalf("NewBoltAdapter: %v", err)
+	}
+	if err := adapter.Initialize(); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = adapter.Close()
+	})
+
+	return adapter
 }
 
 // ==========================================
@@ -805,5 +825,62 @@ func TestHandleSettingsSetAsMain_RotatesConnectionEventChannel(t *testing.T) {
 	}
 	if updated.eventStreamCtx == nil {
 		t.Fatal("expected a replacement event stream context after database switch")
+	}
+}
+
+// ==========================================
+// Persistence Bug Test
+// ==========================================
+
+func TestHandleSettingsSetAsMain_PersistsDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	boltAdapter := newTestBoltAdapter(t)
+	settingsRepo := boltdb.NewDatabaseSettingsRepository(boltAdapter)
+
+	defaultConfig := newTestDatabaseSettings(t, "DEFAULT-DB")
+	defaultConfig.SetAsDefault()
+	if err := settingsRepo.Save(ctx, *defaultConfig); err != nil {
+		t.Fatalf("failed to save default config: %v", err)
+	}
+
+	nonDefaultConfig := newTestDatabaseSettings(t, "NON-DEFAULT-DB")
+	if err := settingsRepo.Save(ctx, *nonDefaultConfig); err != nil {
+		t.Fatalf("failed to save non-default config: %v", err)
+	}
+
+	m := newTestModelForSettings(t)
+	mockDB := NewMockDatabaseRepository()
+	m.appConfig = defaultConfig
+	m.dbAdapter = mockDB
+	m.boltAdapter = boltAdapter
+
+	m.dbFactory = func(cfg *domain.DatabaseSettings) (ports.DatabaseRepository, error) {
+		return mockDB, nil
+	}
+
+	updated, _ := m.handleSettingsSetAsMain(*nonDefaultConfig)
+
+	if updated.appConfig == nil {
+		t.Fatal("expected appConfig to be set after switch")
+	}
+	if updated.appConfig.DatabaseID() != "NON-DEFAULT-DB" {
+		t.Fatalf("expected appConfig to be NON-DEFAULT-DB, got %s", updated.appConfig.DatabaseID())
+	}
+
+	if err := updated.markActiveConnectionPermissionsValidated(); err != nil {
+		t.Fatalf("markActiveConnectionPermissionsValidated: %v", err)
+	}
+
+	reloadedDefault, err := settingsRepo.GetDefault(ctx)
+	if err != nil {
+		t.Fatalf("failed to reload default config: %v", err)
+	}
+	if reloadedDefault == nil {
+		t.Fatal("expected default config to exist after reload")
+	}
+	if reloadedDefault.DatabaseID() != "NON-DEFAULT-DB" {
+		t.Errorf("expected default pointer to be NON-DEFAULT-DB after switch, got %s", reloadedDefault.DatabaseID())
 	}
 }

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -832,7 +832,7 @@ func TestHandleSettingsSetAsMain_RotatesConnectionEventChannel(t *testing.T) {
 // Persistence Bug Test
 // ==========================================
 
-func TestHandleSettingsSetAsMain_PersistsDefault(t *testing.T) {
+func TestSetAsMain_ThenValidate_PersistsDefault(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -869,10 +869,6 @@ func TestSetAsMain_ThenValidate_PersistsDefault(t *testing.T) {
 		t.Fatalf("expected appConfig to be NON-DEFAULT-DB, got %s", updated.appConfig.DatabaseID())
 	}
 
-	if err := updated.markActiveConnectionPermissionsValidated(); err != nil {
-		t.Fatalf("markActiveConnectionPermissionsValidated: %v", err)
-	}
-
 	reloadedDefault, err := settingsRepo.GetDefault(ctx)
 	if err != nil {
 		t.Fatalf("failed to reload default config: %v", err)
@@ -882,5 +878,20 @@ func TestSetAsMain_ThenValidate_PersistsDefault(t *testing.T) {
 	}
 	if reloadedDefault.DatabaseID() != "NON-DEFAULT-DB" {
 		t.Errorf("expected default pointer to be NON-DEFAULT-DB after switch, got %s", reloadedDefault.DatabaseID())
+	}
+
+	// Verify that only one config is marked as default
+	allConfigs, err := settingsRepo.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("failed to reload all configs: %v", err)
+	}
+	defaultCount := 0
+	for _, cfg := range allConfigs {
+		if cfg.IsDefault() {
+			defaultCount++
+		}
+	}
+	if defaultCount != 1 {
+		t.Fatalf("expected exactly one default config, got %d", defaultCount)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default database selection now reliably persists, updates the UI to show exactly one default, and surfaces an error if saving fails.

* **New Features**
  * Switching the default database is now handled atomically to avoid duplicate defaults during save.

* **Tests**
  * Added tests verifying default selection persistence and single-default enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->