### PR TITLE
feat(database): implement retry mechanism for database connection wit…

### DIFF
--- a/internal/adapter/ui/commands.go
+++ b/internal/adapter/ui/commands.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -94,6 +95,22 @@ func waitForUpdateEventCmd(ctx context.Context, ch <-chan tea.Msg) tea.Cmd {
 			return msg
 		case <-ctx.Done():
 			return updateCompleteMsg{}
+		}
+	}
+}
+
+// waitForRetryTimerCmd waits for the retry timer to expire or the context to be cancelled.
+func waitForRetryTimerCmd(ctx context.Context, timer *time.Timer, generation int) tea.Cmd {
+	return func() tea.Msg {
+		if timer == nil {
+			return retryTimerExpiryMsg{generation: generation}
+		}
+
+		select {
+		case <-timer.C:
+			return retryTimerExpiryMsg{generation: generation}
+		case <-ctx.Done():
+			return retryTimerExpiryMsg{generation: generation}
 		}
 	}
 }

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -379,9 +379,11 @@ func (m *Model) handleSettingsSetAsMain(selectedDb domain.DatabaseSettings) (*Mo
 	m.main.renderedContent.Reset()
 	m.main.ready = false
 	m.closeDatabaseSettings()
+	m.stopLoadingRetryTimer()
 	m.screen = screenLoading
 	m.loading.steps = nil
 	m.loading.err = nil
+	m.loading.retryCount = 0
 	m.loading.current = "Connecting..."
 	return m, connectDBCmd(m, true)
 }

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // ==========================================
@@ -336,6 +337,73 @@ func TestHandleSettingsSetAsMain_ServiceCleanup_NilDbAdapter(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Error("expected non-nil command to be returned")
+	}
+}
+
+func TestHandleSettingsSetAsMain_ResetsRetryState(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModelForSettings(t)
+	boltAdapter := newTestBoltAdapter(t)
+	oldMockDB := NewMockDatabaseRepository()
+	newMockDB := NewMockDatabaseRepository()
+
+	m.boltAdapter = boltAdapter
+	m.dbAdapter = oldMockDB
+	m.appConfig = newTestDatabaseSettings(t, "OLD-DB")
+	m.loading.retryCount = 4
+	m.loading.retryTimer = time.NewTimer(time.Hour)
+	retryCtx, retryCancel := context.WithCancel(context.Background())
+	m.loading.retryCancel = retryCancel
+	m.loading.retryGeneration = 7
+
+	selected := newTestDatabaseSettings(t, "NEW-DB")
+	m.dbFactory = func(cfg *domain.DatabaseSettings) (ports.DatabaseRepository, error) {
+		return newMockDB, nil
+	}
+
+	updated, cmd := m.handleSettingsSetAsMain(*selected)
+	if cmd == nil {
+		t.Fatal("expected connect command after switching databases")
+	}
+	if updated.loading.retryCount != 0 {
+		t.Fatalf("expected retryCount to reset to 0, got %d", updated.loading.retryCount)
+	}
+	if updated.loading.retryTimer != nil {
+		t.Fatal("expected retryTimer to be cleared after switching databases")
+	}
+	if updated.loading.retryCancel != nil {
+		t.Fatal("expected retryCancel to be cleared after switching databases")
+	}
+
+	select {
+	case <-retryCtx.Done():
+	default:
+		t.Fatal("expected previous retry context to be cancelled when switching databases")
+	}
+	if updated.loading.retryGeneration <= 7 {
+		t.Fatalf("expected retryGeneration to advance, got %d", updated.loading.retryGeneration)
+	}
+	if updated.loading.current != "Connecting..." {
+		t.Fatalf("expected loading current to reset to connecting, got %q", updated.loading.current)
+	}
+	if updated.screen != screenLoading {
+		t.Fatalf("expected screen to switch to loading, got %q", updated.screen)
+	}
+	if updated.appConfig == nil || updated.appConfig.DatabaseID() != "NEW-DB" {
+		t.Fatal("expected active database configuration to be updated")
+	}
+	if updated.dbAdapter != newMockDB {
+		t.Fatal("expected dbAdapter to be replaced with the new adapter")
+	}
+	if len(newMockDB.ConnectCalls) != 1 {
+		t.Fatalf("expected new adapter validation connect, got %d", len(newMockDB.ConnectCalls))
+	}
+	if len(newMockDB.CloseCalls) != 1 {
+		t.Fatalf("expected new adapter validation close, got %d", len(newMockDB.CloseCalls))
+	}
+	if len(oldMockDB.CloseCalls) != 1 {
+		t.Fatalf("expected old adapter close, got %d", len(oldMockDB.CloseCalls))
 	}
 }
 

--- a/internal/adapter/ui/loading.go
+++ b/internal/adapter/ui/loading.go
@@ -2,8 +2,11 @@ package ui
 
 import (
 	"OmniView/internal/adapter/ui/styles"
+	"context"
 	"fmt"
 	"log"
+	"math"
+	"time"
 
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
@@ -16,6 +19,10 @@ import (
 
 // updateLoading handles messages when screen == "loading".
 func (m *Model) updateLoading(msg tea.Msg) (*Model, tea.Cmd) {
+	if m.dbSettings.visible {
+		return m.updateDatabaseSettings(msg)
+	}
+
 	switch msg := msg.(type) {
 
 	// Spinner animation frame
@@ -76,6 +83,57 @@ func (m *Model) updateLoading(msg tea.Msg) (*Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 		}
+		if m.loading.err != nil {
+			switch msg.String() {
+			case "r", "R":
+				m.stopLoadingRetryTimer()
+
+				waitSeconds := math.Min(math.Pow(2, float64(m.loading.retryCount)), 30)
+				retryCtx, retryCancel := context.WithCancel(m.ctx)
+				m.loading.retryCancel = retryCancel
+				m.loading.current = fmt.Sprintf("Retrying connection in %.0f seconds...", waitSeconds)
+				m.loading.retryTimer = time.NewTimer(time.Duration(waitSeconds) * time.Second)
+				m.loading.retryCount++
+				return m, waitForRetryTimerCmd(retryCtx, m.loading.retryTimer, m.loading.retryGeneration)
+
+			case "s", "S":
+				return m, func() tea.Msg {
+					return SwitchDatabaseMsg{}
+				}
+
+			case "q", "Q":
+				m.cancel()
+				return m, tea.Quit
+			}
+		}
+
+	case retryTimerExpiryMsg:
+		if msg.generation != m.loading.retryGeneration || m.loading.retryTimer == nil {
+			return m, nil
+		}
+
+		m.stopLoadingRetryTimer()
+		m.loading.err = nil
+		m.loading.current = "Connecting to database..."
+		return m, connectDBCmd(m, false)
+
+	case SwitchDatabaseMsg:
+		m.stopLoadingRetryTimer()
+		m.loading.current = ""
+
+		activeID := ""
+		if m.appConfig != nil {
+			activeID = m.appConfig.ID()
+		}
+
+		databases, err := m.dbSettingsRepo.GetAll(m.ctx)
+		if err != nil {
+			log.Printf("[UI] Failed to load database settings: %v", err)
+			databases = nil
+		}
+
+		m.initDatabaseSettings(databases, activeID)
+		return m, nil
 
 	// Update progress
 	case updateProgressMsg:
@@ -99,8 +157,11 @@ func (m *Model) updateLoading(msg tea.Msg) (*Model, tea.Cmd) {
 	case dbConnectedMsg:
 		if msg.err != nil {
 			m.loading.err = fmt.Errorf("database connection failed: %w", msg.err)
+			m.loading.current = ""
 			return m, nil
 		}
+		m.loading.retryCount = 0
+		m.loading.retryTimer = nil
 		m.loading.steps = append(m.loading.steps, "✓ Connected to Oracle database")
 
 		// Initialize services before proceeding
@@ -180,6 +241,28 @@ func (m *Model) updateLoading(msg tea.Msg) (*Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m *Model) stopLoadingRetryTimer() {
+	m.loading.retryGeneration++
+
+	if m.loading.retryCancel != nil {
+		m.loading.retryCancel()
+		m.loading.retryCancel = nil
+	}
+
+	if m.loading.retryTimer == nil {
+		return
+	}
+
+	if !m.loading.retryTimer.Stop() {
+		select {
+		case <-m.loading.retryTimer.C:
+		default:
+		}
+	}
+
+	m.loading.retryTimer = nil
+}
+
 // ==========================================
 // Loading View
 // ==========================================
@@ -243,13 +326,23 @@ func (m *Model) viewLoading() string {
 	}
 
 	if m.loading.err != nil {
+		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+		infoStyle := styles.SubtitleStyle
+
+		errorMsg := fmt.Sprintf("%s %s", errorStyle.Render("✗"), m.loading.err.Error())
+		retryStatus := ""
+		if m.loading.retryTimer != nil && m.loading.current != "" {
+			retryStatus = infoStyle.Render(m.loading.current)
+		}
+
 		lines = append(
 			lines,
 			"",
 			styles.LoadingErrorStyle.Render("Startup blocked"),
-			styles.SubtitleStyle.Width(bodyWidth).Render(m.loading.err.Error()),
+			styles.SubtitleStyle.Width(bodyWidth).Render(errorMsg),
 			"",
-			styles.SubtitleStyle.Render("Press q to exit."),
+			retryStatus,
+			styles.SubtitleStyle.Width(bodyWidth).Render(infoStyle.Render("R Retry  •  S Switch  •  Q Quit")),
 		)
 	} else if m.loading.current != "" {
 		lines = append(
@@ -260,5 +353,13 @@ func (m *Model) viewLoading() string {
 	}
 
 	panel := renderPanel("Startup Status", panelWidth, lipgloss.JoinVertical(lipgloss.Left, lines...))
-	return placeCentered(m.width, m.height, panel)
+	content := placeCentered(m.width, m.height, panel)
+	if m.dbSettings.visible {
+		content = renderCenteredOverlay(content, m.viewDatabaseSettings(), m.width, m.height)
+		if m.dbSettings.showAddForm {
+			content = renderCenteredOverlay(content, m.dbSettings.addForm.Modal(), m.width, m.height)
+		}
+	}
+
+	return content
 }

--- a/internal/adapter/ui/loading.go
+++ b/internal/adapter/ui/loading.go
@@ -162,6 +162,7 @@ func (m *Model) updateLoading(msg tea.Msg) (*Model, tea.Cmd) {
 		}
 		m.loading.retryCount = 0
 		m.loading.retryTimer = nil
+		m.loading.retryCancel = nil
 		m.loading.steps = append(m.loading.steps, "✓ Connected to Oracle database")
 
 		// Initialize services before proceeding

--- a/internal/adapter/ui/loading_test.go
+++ b/internal/adapter/ui/loading_test.go
@@ -7,8 +7,41 @@ import (
 	"OmniView/internal/service/subscribers"
 	"OmniView/internal/service/tracer"
 	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
 )
+
+type stubDatabaseSettingsRepository struct {
+	databases []domain.DatabaseSettings
+	err       error
+}
+
+func (s stubDatabaseSettingsRepository) Save(context.Context, domain.DatabaseSettings) error {
+	return nil
+}
+
+func (s stubDatabaseSettingsRepository) GetByID(context.Context, string) (*domain.DatabaseSettings, error) {
+	return nil, nil
+}
+
+func (s stubDatabaseSettingsRepository) GetDefault(context.Context) (*domain.DatabaseSettings, error) {
+	return nil, nil
+}
+
+func (s stubDatabaseSettingsRepository) GetAll(context.Context) ([]domain.DatabaseSettings, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.databases, nil
+}
+
+func (s stubDatabaseSettingsRepository) Delete(context.Context, string) error {
+	return nil
+}
 
 type stubPermissionsRepository struct{}
 
@@ -57,11 +90,372 @@ func newLoadingTestModel(t *testing.T, validated bool) *Model {
 
 	return &Model{
 		ctx:               context.Background(),
+		width:             120,
+		height:            36,
 		appConfig:         settings,
 		dbAdapter:         mockDB,
+		dbSettingsRepo:    stubDatabaseSettingsRepository{},
 		permissionService: permissions.NewPermissionService(mockDB, stubPermissionsRepository{}, configRepo),
 		tracerService:     tracerService,
 		subscriberService: subscribers.NewSubscriberService(mockDB, nil),
+	}
+}
+
+func TestRecoveryOptionsKeyboardHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		key    string
+		assert func(t *testing.T, updated *Model, cmd tea.Cmd)
+	}{
+		{
+			name: "retry increments count",
+			key:  "r",
+			assert: func(t *testing.T, updated *Model, cmd tea.Cmd) {
+				t.Helper()
+				if cmd == nil {
+					t.Fatal("expected retry command")
+				}
+				if updated.loading.retryCount != 1 {
+					t.Fatalf("expected retryCount to increment to 1, got %d", updated.loading.retryCount)
+				}
+				if updated.loading.retryTimer == nil {
+					t.Fatal("expected retry timer to be created")
+				}
+				if updated.loading.current != "Retrying connection in 1 seconds..." {
+					t.Fatalf("expected first retry to wait 1 second, got %q", updated.loading.current)
+				}
+				defer updated.loading.retryTimer.Stop()
+
+				updated.cancel()
+				if _, ok := cmd().(retryTimerExpiryMsg); !ok {
+					t.Fatal("expected retry timer command to emit retryTimerExpiryMsg")
+				}
+			},
+		},
+		{
+			name: "switch emits SwitchDatabaseMsg",
+			key:  "s",
+			assert: func(t *testing.T, updated *Model, cmd tea.Cmd) {
+				t.Helper()
+				if cmd == nil {
+					t.Fatal("expected switch command")
+				}
+				if _, ok := cmd().(SwitchDatabaseMsg); !ok {
+					t.Fatal("expected SwitchDatabaseMsg")
+				}
+				if updated.loading.retryCount != 0 {
+					t.Fatalf("expected retryCount to remain unchanged, got %d", updated.loading.retryCount)
+				}
+			},
+		},
+		{
+			name: "quit returns tea.Quit",
+			key:  "q",
+			assert: func(t *testing.T, updated *Model, cmd tea.Cmd) {
+				t.Helper()
+				if cmd == nil {
+					t.Fatal("expected quit command")
+				}
+				if _, ok := cmd().(tea.QuitMsg); !ok {
+					t.Fatal("expected tea.QuitMsg")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newLoadingTestModel(t, false)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			m.ctx = ctx
+			m.cancel = cancel
+			m.loading.err = errors.New("connection refused")
+
+			updated, cmd := m.updateLoading(makeCharPress(tt.key))
+			tt.assert(t, updated, cmd)
+		})
+	}
+}
+
+func TestRetryTimerExpiryReattemptsDatabaseConnection(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	m.loading.err = errors.New("connection refused")
+	m.loading.retryCount = 1
+	m.loading.retryTimer = time.NewTimer(time.Hour)
+	defer func() {
+		if m.loading.retryTimer != nil {
+			m.loading.retryTimer.Stop()
+		}
+	}()
+
+	updated, cmd := m.updateLoading(retryTimerExpiryMsg{})
+	if cmd == nil {
+		t.Fatal("expected reconnect command after retry timer expiry")
+	}
+	if updated.loading.retryTimer != nil {
+		t.Fatal("expected retry timer to be cleared after expiry")
+	}
+	if updated.loading.err != nil {
+		t.Fatalf("expected loading error to be cleared, got %v", updated.loading.err)
+	}
+	if updated.loading.current != "Connecting to database..." {
+		t.Fatalf("expected loading current to reset to connecting, got %q", updated.loading.current)
+	}
+
+	connectResult, ok := cmd().(dbConnectedMsg)
+	if !ok {
+		t.Fatal("expected dbConnectedMsg from reconnect command")
+	}
+	if connectResult.err != nil {
+		t.Fatalf("expected reconnect attempt to succeed, got %v", connectResult.err)
+	}
+
+	mockDB, ok := m.dbAdapter.(*MockDatabaseRepository)
+	if !ok {
+		t.Fatal("expected mock database adapter")
+	}
+	if len(mockDB.ConnectCalls) != 1 {
+		t.Fatalf("expected one reconnect attempt, got %d", len(mockDB.ConnectCalls))
+	}
+}
+
+func TestRetryTimerExpiryIgnoresStaleGeneration(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	m.loading.err = errors.New("connection refused")
+	m.loading.retryTimer = time.NewTimer(time.Hour)
+	m.loading.retryGeneration = 2
+	defer func() {
+		if m.loading.retryTimer != nil {
+			m.loading.retryTimer.Stop()
+		}
+	}()
+
+	updated, cmd := m.updateLoading(retryTimerExpiryMsg{generation: 1})
+	if cmd != nil {
+		t.Fatal("expected stale retry expiry to be ignored")
+	}
+	if updated.loading.retryTimer == nil {
+		t.Fatal("expected active retry timer to remain unchanged")
+	}
+	if updated.loading.err == nil {
+		t.Fatal("expected loading error to remain set")
+	}
+
+	mockDB, ok := m.dbAdapter.(*MockDatabaseRepository)
+	if !ok {
+		t.Fatal("expected mock database adapter")
+	}
+	if len(mockDB.ConnectCalls) != 0 {
+		t.Fatalf("expected no reconnect attempt for stale retry expiry, got %d", len(mockDB.ConnectCalls))
+	}
+	updated.loading.retryTimer.Stop()
+	updated.loading.retryTimer = nil
+}
+
+func TestUpdateLoading_SecondRetryInvalidatesFirstRetryCommand(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m.ctx = ctx
+	m.cancel = cancel
+	m.loading.err = errors.New("database unavailable")
+
+	firstRetry, firstCmd := m.updateLoading(makeCharPress("r"))
+	if firstCmd == nil {
+		t.Fatal("expected first retry command")
+	}
+	if firstRetry.loading.retryTimer == nil {
+		t.Fatal("expected first retry timer")
+	}
+
+	secondRetry, secondCmd := firstRetry.updateLoading(makeCharPress("r"))
+	if secondCmd == nil {
+		t.Fatal("expected second retry command")
+	}
+	if secondRetry.loading.retryTimer == nil {
+		t.Fatal("expected second retry timer")
+	}
+	defer func() {
+		if secondRetry.loading.retryTimer != nil {
+			secondRetry.loading.retryTimer.Stop()
+		}
+	}()
+
+	staleMsg, ok := firstCmd().(retryTimerExpiryMsg)
+	if !ok {
+		t.Fatal("expected first retry command to emit retryTimerExpiryMsg")
+	}
+	updated, cmd := secondRetry.updateLoading(staleMsg)
+	if cmd != nil {
+		t.Fatal("expected stale retry expiry to be ignored")
+	}
+	if updated.loading.retryTimer == nil {
+		t.Fatal("expected second retry timer to remain active")
+	}
+
+	mockDB, ok := updated.dbAdapter.(*MockDatabaseRepository)
+	if !ok {
+		t.Fatal("expected mock database adapter")
+	}
+	if len(mockDB.ConnectCalls) != 0 {
+		t.Fatalf("expected no reconnect attempt from stale retry command, got %d", len(mockDB.ConnectCalls))
+	}
+	if updated.loading.retryCount != 2 {
+		t.Fatalf("expected second retry state to remain active, got retryCount=%d", updated.loading.retryCount)
+	}
+	if updated.loading.current != "Retrying connection in 2 seconds..." {
+		t.Fatalf("expected second retry delay to remain visible, got %q", updated.loading.current)
+	}
+	if staleMsg.generation == updated.loading.retryGeneration {
+		t.Fatal("expected first retry generation to differ from active retry generation")
+	}
+}
+
+func TestUpdateLoading_RetryKeySchedulesBackoff(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.ctx = ctx
+	m.loading.err = errors.New("database unavailable")
+
+	updated, cmd := m.updateLoading(makeCharPress("r"))
+	if cmd == nil {
+		t.Fatal("expected retry timer command")
+	}
+	if updated.loading.retryCount != 1 {
+		t.Fatalf("expected retryCount to increment to 1, got %d", updated.loading.retryCount)
+	}
+	if updated.loading.retryTimer == nil {
+		t.Fatal("expected retryTimer to be created")
+	}
+	defer func() {
+		if updated.loading.retryTimer != nil {
+			updated.loading.retryTimer.Stop()
+		}
+	}()
+	if updated.loading.current != "Retrying connection in 1 seconds..." {
+		t.Fatalf("expected retry message, got %q", updated.loading.current)
+	}
+	cancel()
+	if _, ok := cmd().(retryTimerExpiryMsg); !ok {
+		t.Fatal("expected retry timer command to emit retryTimerExpiryMsg")
+	}
+}
+
+func TestUpdateLoading_RetryKeyCapsBackoffAtThirtySeconds(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m.ctx = ctx
+	m.loading.err = errors.New("database unavailable")
+	m.loading.retryCount = 5
+
+	updated, cmd := m.updateLoading(makeCharPress("r"))
+	if cmd == nil {
+		t.Fatal("expected retry timer command")
+	}
+	if updated.loading.retryCount != 6 {
+		t.Fatalf("expected retryCount to increment to 6, got %d", updated.loading.retryCount)
+	}
+	if updated.loading.current != "Retrying connection in 30 seconds..." {
+		t.Fatalf("expected capped retry message, got %q", updated.loading.current)
+	}
+	if updated.loading.retryTimer == nil {
+		t.Fatal("expected retryTimer to be created")
+	}
+	updated.loading.retryTimer.Stop()
+}
+
+func TestViewLoading_ShowsRetryStatusWhenRetryScheduled(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	m.loading.err = errors.New("database unavailable")
+	m.loading.current = "Retrying connection in 4 seconds..."
+	m.loading.retryTimer = time.NewTimer(time.Hour)
+	defer m.loading.retryTimer.Stop()
+
+	view := m.viewLoading()
+	if !strings.Contains(view, "Retrying connection in 4 seconds...") {
+		t.Fatalf("expected retry status to be visible in loading view, got %q", view)
+	}
+	if !strings.Contains(view, "R Retry") || !strings.Contains(view, "S Switch") || !strings.Contains(view, "Q Quit") {
+		t.Fatalf("expected horizontal recovery options to be visible in loading view, got %q", view)
+	}
+	if strings.Contains(view, "A]dd") || strings.Contains(view, "A Add") {
+		t.Fatalf("expected Add option to be absent from loading view, got %q", view)
+	}
+	if strings.Contains(view, "What would you like to do?") {
+		t.Fatalf("expected question prompt to be removed from loading view, got %q", view)
+	}
+}
+
+func TestUpdateLoading_SwitchDatabaseMsgOpensSettingsOverlay(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	m.loading.err = errors.New("database unavailable")
+	m.loading.retryTimer = time.NewTimer(time.Hour)
+	m.dbSettingsRepo = stubDatabaseSettingsRepository{
+		databases: []domain.DatabaseSettings{*newTestDatabaseSettings(t, "ALT-DB")},
+	}
+
+	updated, cmd := m.updateLoading(makeCharPress("s"))
+	if cmd == nil {
+		t.Fatal("expected switch database command")
+	}
+	if _, ok := cmd().(SwitchDatabaseMsg); !ok {
+		t.Fatal("expected switch database message")
+	}
+
+	updated, cmd = m.updateLoading(SwitchDatabaseMsg{})
+	if cmd != nil {
+		t.Fatal("expected no follow-up command when opening settings overlay")
+	}
+	if !updated.dbSettings.visible {
+		t.Fatal("expected database settings overlay to be visible")
+	}
+	if len(updated.dbSettings.databases) != 1 {
+		t.Fatalf("expected one stored database, got %d", len(updated.dbSettings.databases))
+	}
+	if updated.loading.retryTimer != nil {
+		t.Fatal("expected retry timer to be cleared when opening settings overlay")
+	}
+}
+
+func TestModelUpdate_LoadingOverlayQClosesOverlay(t *testing.T) {
+	t.Parallel()
+
+	m := newLoadingTestModel(t, false)
+	m.screen = screenLoading
+	m.dbSettings.visible = true
+
+	updatedModel, cmd := m.Update(makeCharPress("q"))
+	if cmd != nil {
+		t.Fatal("expected q to be handled by overlay without quitting")
+	}
+
+	updated, ok := updatedModel.(*Model)
+	if !ok {
+		t.Fatal("expected Update to return *Model")
+	}
+	if updated.dbSettings.visible {
+		t.Fatal("expected q to close the loading overlay")
 	}
 }
 

--- a/internal/adapter/ui/model.go
+++ b/internal/adapter/ui/model.go
@@ -50,10 +50,14 @@ type welcomeState struct {
 }
 
 type loadingState struct {
-	steps   []string      // Completed steps descriptions
-	current string        // Step currently in progress
-	err     error         // Error encountered during loading, if any
-	spinner spinner.Model // Animated dots TODO: Make this into a loading progress bar
+	steps           []string           // Completed steps descriptions
+	current         string             // Step currently in progress
+	err             error              // Error encountered during loading, if any
+	retryCount      int                // Number of retry attempts performed
+	retryGeneration int                // Generation token for distinguishing stale retry expiries
+	retryTimer      *time.Timer        // Timer for scheduling the next retry attempt
+	retryCancel     context.CancelFunc // Cancel func for the active retry wait command
+	spinner         spinner.Model      // Animated dots TODO: Make this into a loading progress bar
 }
 
 type mainState struct {
@@ -86,6 +90,16 @@ type updateState struct {
 	applying  bool                // Whether the update is being applied
 	stage     string              // Current progress stage description
 	err       error               // Error encountered, if any
+}
+
+// ==========================================
+// Connection Recovery Messages
+// ==========================================
+
+type SwitchDatabaseMsg struct{}
+
+type retryTimerExpiryMsg struct {
+	generation int
 }
 
 // ==========================================
@@ -297,7 +311,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "q":
 			// Only quit from screens that don't need 'q' for navigation
-			if (m.screen == screenMain && !m.dbSettings.visible) || m.screen == screenWelcome || m.screen == screenLoading {
+			if (m.screen == screenMain && !m.dbSettings.visible) || m.screen == screenWelcome || (m.screen == screenLoading && !m.dbSettings.visible) {
 				m.cancel()
 				return m, tea.Quit
 			}


### PR DESCRIPTION
…h state management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry on database connection failure with exponential backoff (displayed countdown, capped at 30 seconds).
  * Keyboard shortcuts on the loading screen: R to retry, S to open database settings overlay, Q to quit.
  * Database settings overlay accessible from the loading screen, including the add-form modal overlay.

* **Bug Fixes / Behavior**
  * Retry state is properly reset/cancelled when switching databases or after connection completes; stale retries are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->