### PR TITLE
fix(cmd): emit CSI 8 terminal resize on Windows TTY

### DIFF
--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -76,11 +76,12 @@ func main() {
 	const minRows = 36
 	const minCols = 130
 	if fi, err := os.Stdout.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+		// Windows CMD/legacy often has no TERM; still emit CSI resize for ConPTY / WT / console.
 		term := os.Getenv("TERM")
-		// Windows: CMD/legacy often has no TERM; still emit CSI resize for ConPTY / WT / console.
-		if runtime.GOOS == "windows" {
-			fmt.Printf("\033[8;%d;%dt", minRows, minCols)
-		} else if (term != "" && term != "dumb") || os.Getenv("WT_SESSION") != "" {
+		emit := runtime.GOOS == "windows" ||
+			(term != "" && term != "dumb") ||
+			os.Getenv("WT_SESSION") != ""
+		if emit {
 			fmt.Printf("\033[8;%d;%dt", minRows, minCols)
 		}
 	}

--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -12,6 +12,7 @@ import (
 	"OmniView/internal/updater"
 	"fmt"
 	"os"
+	"runtime"
 )
 
 func main() {
@@ -76,7 +77,10 @@ func main() {
 	const minCols = 130
 	if fi, err := os.Stdout.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
 		term := os.Getenv("TERM")
-		if (term != "" && term != "dumb") || os.Getenv("WT_SESSION") != "" {
+		// Windows: CMD/legacy often has no TERM; still emit CSI resize for ConPTY / WT / console.
+		if runtime.GOOS == "windows" {
+			fmt.Printf("\033[8;%d;%dt", minRows, minCols)
+		} else if (term != "" && term != "dumb") || os.Getenv("WT_SESSION") != "" {
 			fmt.Printf("\033[8;%d;%dt", minRows, minCols)
 		}
 	}


### PR DESCRIPTION
On Windows, TERM is often empty in CMD/legacy consoles, so the prior

TERM/WT_SESSION gate never ran. Use runtime.GOOS for a character

device; keep TERM/WT gating for other OSes.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal resize handling on Windows now works reliably regardless of terminal environment variables, improving viewport updates in Windows terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->