### PR TITLE
fix(oracle): remove unnecessary CGO directives for Linux

### DIFF
--- a/internal/adapter/storage/oracle/oracle_adapter.go
+++ b/internal/adapter/storage/oracle/oracle_adapter.go
@@ -4,9 +4,6 @@ package oracle
 #cgo darwin CFLAGS: -I${SRCDIR}/../../../../third_party/odpi/include
 #cgo darwin LDFLAGS: -L/opt/oracle/instantclient_23_7 -lclntsh -L${SRCDIR}/../../../../third_party/odpi/lib -lodpi
 
-#cgo linux CFLAGS: -I${SRCDIR}/../../../../third_party/odpi/include
-#cgo linux LDFLAGS: -L/opt/oracle/instantclient_23_7 -lclntsh -L${SRCDIR}/../../../../third_party/odpi/lib -lodpi
-
 #cgo windows CFLAGS: -I${SRCDIR}/../../../../third_party/odpi/include
 #cgo windows LDFLAGS: -L${SRCDIR}/../../../../third_party/odpi/lib -lodpi -LC:/oracle_inst/instantclient_23_7 -loci
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Linux build configuration for the Oracle adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->