### PR TITLE
multi subscriber implementation: Epic 1 User Story 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ skills-lock.json
 omniview.syso
 omniview
 _bmad
-_bmad-output
 .github
 .cursor
 .agents

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,15 +3,18 @@ project_name: "OmniInspect"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -55,53 +58,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -112,11 +79,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -151,3 +121,8 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:

--- a/_bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
+++ b/_bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
@@ -1,0 +1,108 @@
+---
+stepsCompleted: [1, 2, 3, 4]
+inputDocuments:
+  - docs/SUBSCRIBER_ISOLATION_SOLUTION.md
+  - docs/ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md
+session_topic: 'Per-subscriber message isolation for OmniView/OmniInspect trace messages over Oracle AQ, in environments where many users share the ifsapp Oracle login and/or use personal Oracle accounts while the IFS Cloud application layer has its own user identity.'
+session_goals: 'Generate a wide candidate list of architectural approaches (goal: beyond the 5 already drafted), surface cross-cutting mechanisms worth combining, include black-swan/unconventional ideas, capture risks and edge cases, and establish evaluation criteria for later Technical Research. No backward compatibility constraint. Modifying Trace_Message procedure is allowed (package invalidation on redeploy is acceptable).'
+selected_approach: 'ai-recommended'
+techniques_used:
+  - First Principles Thinking
+  - Morphological Analysis
+  - Cross-Pollination
+  - Reverse Brainstorming
+  - SCAMPER
+ideas_generated: 10
+context_file: ''
+session_status: 'complete'
+---
+
+# Brainstorming Session Results
+
+**Facilitator:** Basuruk
+**Date:** 2026-04-19
+**Last Updated:** 2026-04-26 (resumed session)
+
+---
+
+## Session Overview
+
+**Topic:** Per-subscriber message isolation for OmniView/OmniInspect trace messages over Oracle AQ, in environments where many users share the `ifsapp` Oracle login and/or use personal Oracle accounts while the IFS Cloud application layer has its own user identity.
+
+**Goals:** Generate a wide candidate list of architectural approaches (goal: beyond the 5 already drafted), surface cross-cutting mechanisms worth combining, include black-swan/unconventional ideas, capture risks and edge cases, and establish evaluation criteria for later Technical Research.
+
+---
+
+## Context Summary
+
+- **Environment:** IFS Cloud app on Oracle 19c backend. Intranet / test environments on internal servers.
+- **Identity reality (three-way):**
+  1. Oracle DB user OmniInspect subscriber connects as (often `ifsapp`, sometimes a personal account e.g. `basblk`, `tramlk`, `nipwlk`).
+  2. Oracle DB user that the IFS Cloud application connects as when it executes code path calling `Omni_Tracer_API.Trace_Message()` (also often `ifsapp`, sometimes personal).
+  3. IFS Cloud application user (application-level identity, distinct from the Oracle session user).
+- **Scale:** 50+ concurrent users in worst case, mostly funneling through the shared `ifsapp` Oracle account.
+- **Current behavior:** `Trace_Message` pushes to an AQ queue; every connected subscriber sees every message (broadcast).
+- **Desired behavior:** each message deliverable to exactly the intended subscriber.
+- **Degrees of freedom:** May change `Omni_Tracer_API.Trace_Message()` signature/body, queue topology, payload type, subscriber registration. Package invalidation on redeploy is acceptable.
+
+---
+
+## Alternatives Evaluated
+
+| Approach | How it works | Problem for this case |
+|----------|-------------|----------------------|
+| **IP_ADDRESS filtering** | Capture caller's IP, filter at dequeue | IFS Cloud app server ≠ debugging user's IP |
+| **Explicit subscriber parameter** | `Trace_Message('msg', 'INFO', 'SUB_BBB')` | Caller must pass name — human friction |
+| **CLIENT_IDENTIFIER** | App sets ID at connection start | IFS Cloud starts its own sessions — OmniView can't pre-set |
+| **Session Binding Table** | `Bind_Session()` before `Trace_Message()` | IFS Cloud starts its own sessions — binding doesn't correlate |
+| **Rule-based subscriptions** | AQ rules filter by message content | Message still needs subscriber tag |
+| **Dynamic procedure per subscriber** | `TRACE_MESSAGE_<name>('msg')` | ✅ No extra parameter, caller just uses their method |
+
+**Decision: Dynamic procedure per subscriber approach is the best option.**
+
+---
+
+## Edge Cases Resolved
+
+| # | Edge Case | Resolution |
+|---|-----------|------------|
+| 1 | **Name collision** | Use subscriber's existing unique ID for idempotent creation. No prefix needed. |
+| 2 | **Oracle identifier limit** | Any name under 30 characters. |
+| 3 | **SQL injection** | Strict validation: `^[A-Za-z_]+$` — letters and underscores only, no numbers. |
+| 4 | **Package invalidation** | Accepted. App redeploys on restart if package was invalidated. |
+| 5 | **Orphaned methods** | On restart: if method exists, skip creation. Danger zone options for selective/all deletion. |
+| 6 | **IFS Cloud session crash** | No special handling. Clear error shown → user restarts OmniView → redeploys if needed. |
+| 7 | **Permissions** | Any database user can call generated procedures. |
+| 8 | **Duplicate registration** | Check and only create if missing. |
+| 9 | **Scalability** | N subscribers, no hard limit. |
+| 10 | **IFS Cloud compatibility** | No issue — adding procedures doesn't affect existing Trace_Message calls. |
+
+### Additional Resolved Items
+
+1. **Name format**: Less than 30 characters. Format: `^[A-Za-z_]+$` (letters and underscores only, no numbers).
+
+2. **Danger zone options**:
+   - Delete subscriber-specific method only (per-subscriber cleanup)
+   - Drop entire `OMNI_TRACER_API` package (deletes ALL generated methods for all subscribers)
+
+3. **Auto-redeploy on start**: Already implemented — if `OMNI_TRACER_API` package is missing on startup, OmniView redeploys it.
+
+---
+
+## Key Insights from Brainstorming
+
+1. **The fundamental problem**: Caller (IFS Cloud) and subscriber (OmniView user) are completely decoupled — no shared identity, no shared context, no shared anything.
+
+2. **Why existing solutions fail**: Every approach relying on call-time context (IP, CLIENT_IDENTIFIER, session binding) fails because IFS Cloud controls its own sessions — OmniView cannot influence them.
+
+3. **Why dynamic procedure wins**: Moves subscriber identity to *compile-time* — the human picks a memorable name, embeds it in IFS code. No runtime coordination needed. The method name IS the routing key.
+
+4. **Developer ergonomics**: `TRACE_MESSAGE_barnacle('test')` has same friction as `Trace_Message('test')` — one argument, no extra parameter to remember or pass.
+
+---
+
+## Next Step
+
+**Recommendation:** Move to `bmad-create-architecture` in a fresh session to design the implementation.
+
+---

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,0 +1,146 @@
+# OmniInspect Sprint Status
+# Generated: 2026-04-28
+# Project: OmniInspect
+
+sprint:
+  name: "Sprint 1: Multi-Subscriber Implementation"
+  start_date: "2026-04-28"
+  goal: "Implement multi-subscriber procedure generation with funny name system"
+  status: "active"
+
+# ==========================================
+# STATUS DEFINITIONS
+# ==========================================
+# ready-for-dev      → Story is prepared and ready to develop
+# in-progress        → Story is currently being implemented
+# review             → Implementation complete, awaiting review
+# blocked            → Story is blocked by dependency or external factor
+# done               → Story completed and verified
+
+# ==========================================
+# DEVELOPMENT STATUS
+# ==========================================
+development_status:
+
+  # Epic 1 Stories
+  1-1-funny-name-value-object:
+    status: "done"
+    title: "Funny Name Value Object"
+    epic: "Epic 1: Multi-Subscriber Procedure Generation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Review approved. FunnyName value object implemented with 120+ cartoon names, uppercase procedure-safe assignment, collision handling, validation, and passing tests."
+
+  1-2-procedure-generation:
+    status: "ready-for-dev"
+    title: "Procedure Generation with Enqueue_For_Subscriber"
+    epic: "Epic 1: Multi-Subscriber Procedure Generation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Generate TRACE_MESSAGE_<name> procedures that call Enqueue_For_Subscriber"
+
+  1-3-sql-injection-prevention:
+    status: "ready-for-dev"
+    title: "SQL Injection Prevention"
+    epic: "Epic 1: Multi-Subscriber Procedure Generation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Validate funny names against format before DDL generation"
+
+  1-4-auto-deploy-package:
+    status: "ready-for-dev"
+    title: "Auto-Deploy Package on Startup"
+    epic: "Epic 1: Multi-Subscriber Procedure Generation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Check and deploy OMNI_TRACER_API package if missing on startup"
+
+  # Epic 2 Stories
+  2-1-display-procedure-name:
+    status: "ready-for-dev"
+    title: "Display Procedure Name in Header"
+    epic: "Epic 2: TUI Procedure Name Display"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Show OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg') in main screen header"
+
+  # Epic 3 Stories
+  3-1-drop-subscriber-procedure:
+    status: "ready-for-dev"
+    title: "Drop Subscriber Procedure (Danger Zone)"
+    epic: "Epic 3: Danger Zone Implementation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Add danger zone option to delete subscriber-specific procedure"
+
+  3-2-drop-entire-package:
+    status: "ready-for-dev"
+    title: "Drop Entire Package (Danger Zone)"
+    epic: "Epic 3: Danger Zone Implementation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Add danger zone option to drop entire OMNI_TRACER_API package"
+
+# ==========================================
+# SPRINT METRICS
+# ==========================================
+metrics:
+  total_stories: 7
+  completed: 1
+  in_progress: 0
+  ready_for_dev: 6
+  blocked: 0
+  completion_percentage: 14
+
+# ==========================================
+# EPIC SUMMARY
+# ==========================================
+epic_summary:
+  epic-1:
+    title: "Epic 1: Multi-Subscriber Procedure Generation"
+    stories_total: 4
+    stories_completed: 1
+    stories_in_progress: 0
+    status: "in-progress"
+
+  epic-2:
+    title: "Epic 2: TUI Procedure Name Display"
+    stories_total: 1
+    stories_completed: 0
+    stories_in_progress: 0
+    status: "pending"
+
+  epic-3:
+    title: "Epic 3: Danger Zone Implementation"
+    stories_total: 2
+    stories_completed: 0
+    stories_in_progress: 0
+    status: "pending"
+
+# ==========================================
+# NEXT ACTIONS
+# ==========================================
+next_actions:
+  - story: "1-2-procedure-generation"
+    action: "Implement procedure generation with Enqueue_For_Subscriber"
+    priority: "high"
+    depends_on: ["1-1-funny-name-value-object"]
+
+# ==========================================
+# RECENT Activity
+# ==========================================
+activity_log:
+  - date: "2026-04-28"
+    story: "1-1-funny-name-value-object"
+    action: "Implementation started"
+    notes: "Created funny_names.go with curated list and validation"
+
+  - date: "2026-04-28"
+    story: "1-1-funny-name-value-object"
+    action: "Implementation completed"
+    notes: "Tests passing, funny name value object ready for review"
+
+  - date: "2026-04-28"
+    story: "1-1-funny-name-value-object"
+    action: "Review approved"
+    notes: "Review findings fixed; make test and make lint passing; doc comments added to all exported functions; domain error location rule documented in project-context.md"

--- a/_bmad-output/implementation-artifacts/stories/1-1-funny-name-value-object.md
+++ b/_bmad-output/implementation-artifacts/stories/1-1-funny-name-value-object.md
@@ -1,0 +1,184 @@
+---
+story_key: "1-1-funny-name-value-object"
+epic_key: "epic-1"
+title: "Funny Name Value Object"
+status: "done"
+priority: "high"
+created_date: "2026-04-28"
+last_updated: "2026-04-28"
+---
+
+# ==========================================
+# STORY DEFINITION
+# ==========================================
+
+## Story
+
+As a system,
+I want to auto-assign funny cartoon character names to subscribers,
+So that procedure names are memorable and unique.
+
+## Acceptance Criteria
+
+**Given** a new subscriber registers with OmniView
+**When** the system generates their procedure
+**Then** a funny name (e.g., BARNACLE, PICKLES, NIBBLES) is automatically assigned from the curated list
+**And** the resulting procedure is `OMNI_TRACER_API.TRACE_MESSAGE_BARNACLE('msg')`
+
+**Given** a funny name is already assigned to another subscriber
+**When** a new subscriber registers
+**Then** the system picks another available name to avoid collision
+**And** no two subscribers have the same procedure name
+
+---
+
+## Tasks/Subtasks
+
+- [x] Create `internal/core/domain/funny_names.go` with curated list of 120+ cartoon character names
+- [x] Implement `FunnyNameGenerator` struct with thread-safe random name assignment
+- [x] Add collision handling - system picks another available name when name is already used
+- [x] Implement format validation (`^[A-Za-z_]+$`) for SQL injection prevention
+- [x] Add error types: `ErrInvalidFunnyName`, `ErrNoAvailableNames`, `ErrFunnyNameTooLong`, `ErrFunnyNameTooShort`
+- [x] Write comprehensive unit tests covering all functionality
+- [x] Verify all tests pass
+
+---
+
+## Dev Notes
+
+### Implementation Decisions
+
+1. **Name Format**: Less than 30 characters, format `^[A-Za-z_]+$` (letters and underscores only, no numbers)
+2. **Name Storage**: Curated list of 120+ cartoon character names stored as constant array in `funny_names.go`
+3. **Collision Handling**: Uses `FunnyNameGenerator` with `used` map tracking assigned names; picks another if collision occurs
+4. **Thread Safety**: Generator uses `sync.Mutex` for safe concurrent access
+5. **Validation**: Two-layer validation - format check then list membership check
+
+### Project Context (from SuperMemory)
+
+- Dynamic procedure generation: Uses ExecuteStatement() with runtime-generated DDL strings, NOT embedded files
+- Funny name auto-assignment system: Curated list of 100+ cartoon character names (Mickey, Donald, Bugs, Daffy, Scooby, Tom, Jerry, etc.)
+- System auto-assigns on subscriber creation, user has NO visibility into or choice over the name
+- Collision handling: system picks another available name
+- Full procedure name: `TRACE_MESSAGE_<FUNNY_NAME>` (e.g., `TRACE_MESSAGE_BARNACLE`)
+
+### Key Files
+
+- `internal/core/domain/funny_names.go` - FunnyNameGenerator, validation functions, curated name list
+- `internal/core/domain/funny_names_test.go` - 16 test cases covering validation, generation, collision handling
+
+---
+
+## Dev Agent Record
+
+### Implementation Plan
+
+**Approach**: Created value object following existing domain patterns (BatchSize, WaitTime)
+
+**Files Created**:
+- `internal/core/domain/funny_names.go` (331 lines)
+- `internal/core/domain/funny_names_test.go` (333 lines)
+
+**Key Implementation Details**:
+1. `FunnyName` struct with `String()` and `IsValid()` methods
+2. `FunnyNameGenerator` with `GetRandomName()`, `MarkAsUsed()`, `MarkAsAvailable()`, `Reset()`
+3. Global `ValidateFunnyNameFormat()` for format validation
+4. Global `IsValidFunnyName()` for list membership validation
+5. Singleton pattern via `DefaultFunnyNameGenerator()` with `sync.Once`
+6. Domain sentinel errors registered in `internal/core/domain/errors.go`
+7. Fixed duplicate "Nibbles" entry in curated list
+8. Added missing "Tom" entry
+
+**Tests**: 16 tests covering format validation, list validation, generator functionality, thread safety, case insensitivity
+
+### Debug Log
+
+- Initial build had compilation error (`_, err = gen.GetRandomName()` missing `:=`)
+- Fixed by changing to `_, err := gen.GetRandomName()`
+- Duplicate "Nibbles" in name list caused test failure in `TestFunnyNameGenerator_NoDuplicates`
+- Missing "Tom" caused test failure in `TestIsValidFunnyName_FromList`
+
+### Completion Notes
+
+✅ Story 1-1 completed: FunnyName value object implemented with:
+- 120+ curated cartoon character names
+- Thread-safe `FunnyNameGenerator` with collision handling
+- Format validation (`^[A-Za-z_]+$`)
+- List membership validation
+- Comprehensive unit tests (16 tests, all passing)
+
+---
+
+## File List
+
+**Created:**
+- `internal/core/domain/funny_names.go`
+- `internal/core/domain/funny_names_test.go`
+
+**Modified:**
+- `internal/core/domain/errors.go`
+
+---
+
+## Change Log
+
+- **2026-04-28**: Initial implementation of FunnyName value object with curated name list and collision handling
+- **2026-04-28**: Added comprehensive unit tests, all 16 tests passing
+
+---
+
+## Status History
+
+| Date | Status | Notes |
+|------|--------|-------|
+| 2026-04-28 | ready-for-dev | Story created from epics |
+| 2026-04-28 | in-progress | Development started |
+| 2026-04-28 | review | Implementation complete, tests passing |
+| 2026-04-28 | done | Completed |
+
+---
+
+## Senior Developer Review (AI)
+
+### Review Outcome
+
+**Approved** - Story 1.1 is complete and ready to close.
+
+### Review Date
+
+2026-04-28
+
+### Findings
+
+No remaining blocking findings.
+
+Issues found during review were fixed before approval:
+- Generated names now normalize to uppercase for procedure-safe names such as `TRACE_MESSAGE_BARNACLE`
+- `IsValidFunnyName()` no longer trims leading/trailing spaces before validation
+- Funny name sentinel errors now live in `internal/core/domain/errors.go`
+- Nondeterministic availability test assertion was removed
+
+### Verification
+
+- `go test ./internal/core/domain -run "FunnyName"` passed
+- `make test` passed
+- `make lint` passed
+
+### Action Items
+
+- [x] Normalize generated funny names to uppercase
+- [x] Reject leading/trailing spaces in `IsValidFunnyName()`
+- [x] Move funny name sentinel errors to domain errors
+- [x] Remove nondeterministic test expectation
+- [x] Add doc comments to all exported functions and methods
+
+### Additional Changes After Review
+
+- Added doc comments to all exported functions and methods in `funny_names.go`
+- Documented domain sentinel error location rule in `project-context.md`
+
+---
+
+## Review Follow-ups (AI)
+
+*To be added if review requires changes*

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -1,0 +1,109 @@
+---
+stepsCompleted: [1, 2]
+inputDocuments:
+  - _bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
+  - docs/SUBSCRIBER_ISOLATION_SOLUTION.md
+  - docs/ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md
+  - DESIGN.md
+workflowType: 'architecture'
+project_name: OmniInspect
+user_name: Basuruk
+date: '2026-04-26'
+---
+
+# Architecture Decision Document
+
+_This document builds collaboratively through step-by-step discovery. Sections are appended as we work through each architectural decision together._
+
+## Input Documents
+
+| Document | Purpose |
+|----------|---------|
+| `brainstorming-session-2026-04-19-2221.md` | Solution decisions, edge cases resolved |
+| `SUBSCRIBER_ISOLATION_SOLUTION.md` | Original solution options (IP filtering, explicit param, CLIENT_IDENTIFIER, session binding, hybrid) |
+| `ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md` | Current architecture, obsolete components, multi-subscriber implementation plan |
+| `DESIGN.md` | UX design specification (target visual language, layout rules, component standards, interaction rules) |
+
+---
+
+## Session Context
+
+**Topic:** Per-subscriber message isolation for OmniView/OmniInspect trace messages over Oracle AQ
+
+**Selected Solution:** Dynamic procedure per subscriber (`TRACE_MESSAGE_<name>('msg')`)
+
+**Key Insight:** Moves subscriber identity to compile-time — the method name IS the routing key.
+
+---
+
+## Resolved Decisions (from Brainstorming)
+
+| Decision | Value |
+|----------|-------|
+| Name format | `< 30 chars, `^[A-Za-z_]+$` (letters and underscores only) |
+| Name uniqueness | Use subscriber's existing unique ID (e.g., `SUB_0CC283A4...`) |
+| Creation | Idempotent - check if exists, only create if missing |
+| SQL injection | Strict format validation before DDL generation |
+| Package invalidation | Accepted risk - app redeploys on restart |
+| Danger zone options | Per-subscriber method deletion OR drop entire OMNI_TRACER_API package |
+| Auto-redeploy | Already implemented - if package missing, OmniView redeploys |
+| Permissions | Any database user can call generated procedures |
+| Scalability | N subscribers supported, no hard limit |
+
+---
+
+## Problem Summary
+
+IFS Cloud executes trace calls under IFS app user identity, NOT the debugging OmniView user. No way to correlate:
+- **Caller**: IFS Cloud session user (producer)
+- **Subscriber**: OmniView user who wants to debug (listener)
+
+**Current state:** All subscribers see all messages (broadcast)
+
+**Desired state:** Each message delivered to exactly the intended subscriber
+
+---
+
+## Project Context Analysis
+
+### Requirements Overview
+
+**Functional Requirements:**
+- FR-1: Generate unique `TRACE_MESSAGE_<subscriber_id>()` procedure per subscriber on registration
+- FR-2: Idempotent creation - check if procedure exists before creating
+- FR-3: **Modify Settings UI** - Add danger zone option to drop subscriber-specific procedure
+- FR-4: **Modify Settings UI** - Add danger zone option to drop entire OMNI_TRACER_API package
+- FR-5: Auto-redeploy package on startup if missing
+- FR-6: Strict name format validation (`^[A-Za-z_]+$`) to prevent SQL injection
+- FR-7: Display the subscriber's method name in TUI - Show the user the exact procedure they must call in their PL/SQL code to receive subscriber-isolated messages (e.g., `OMNI_TRACER_API.TRACE_MESSAGE_SUB_0CC283A4...`)
+
+**Non-Functional Requirements:**
+- NFR-1: Package invalidation is acceptable - app recovers on restart
+- NFR-2: Any database user can call generated procedures
+- NFR-3: Support N concurrent subscribers (no hard limit)
+- NFR-4: Developer ergonomics - `TRACE_MESSAGE_xxx('msg')` same friction as `Trace_Message('msg')`
+
+**Scale & Complexity:**
+- Primary domain: Real-time TUI + Oracle AQ messaging
+- Complexity level: Medium (feature enhancement to existing working system)
+- Estimated new/modified components: Settings screen modification (2-3 new danger zone options)
+- UI patterns: S key opens Settings (already implemented), webhook address currently saved there
+
+### Technical Constraints & Dependencies
+- Go + Bubble Tea v2 + Lip Gloss v2 (existing)
+- Oracle 19c with ODPI-C for database connectivity
+- Existing `OMNI_TRACER_API` package must be extended
+- Existing hexagonal architecture must be respected
+- Settings screen already exists at `internal/adapter/ui/database_settings.go`
+
+### Cross-Cutting Concerns Identified
+- SQL injection prevention via format validation
+- Package invalidation recovery mechanism (already implemented)
+- Backward compatibility with existing `Trace_Message()` callers
+
+---
+
+## Next Step
+
+[C] Continue to evaluate starter templates
+

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -272,7 +272,7 @@ func IsValidFunnyName(name string) bool {
 
 #### Pattern 2: Procedure Generation Method
 
-**File**: `internal/service/subscriber/` (subscriber_service.go)
+**File**: `internal/service/subscribers/` (subscriber_service.go)
 
 ```go
 // GenerateSubscriberProcedure generates the TRACE_MESSAGE_<name> procedure
@@ -362,7 +362,7 @@ For this enhancement, we follow the **extend, not replace** principle:
 
 ### Complete Project Directory Structure
 
-```
+```text
 OmniInspect/
 ├── AGENTS.md                                    # Agent guidelines & patterns
 ├── Makefile                                     # Build commands
@@ -438,7 +438,7 @@ OmniInspect/
 ### Architectural Boundaries
 
 **Component Boundaries:**
-```
+```text
 Composition Root (cmd/omniview/main.go)
          │
          ▼
@@ -469,7 +469,7 @@ Service Layer
 ```
 
 **Domain Layer:**
-```
+```text
 ┌──────────────────────────────────────────────────────────────┐
 │                    Domain Layer                              │
 │  ┌────────────────┐  ┌────────────────┐  ┌───────────────┐  │
@@ -517,7 +517,7 @@ OMNI_TRACER_API
 Per-subscriber procedures are generated as runtime DDL and executed via `ExecuteStatement()` to add them inside the `OMNI_TRACER_API` package body. This requires ALTER PACKAGE which may invalidate the entire package — this is an accepted risk.
 
 **Data Flow:**
-```
+```text
 IFS Cloud → OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg')
          → Enqueue_For_Subscriber(subscriber_=<NAME>, ...)
          → AQ Queue

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -9,7 +9,6 @@ inputDocuments:
   - docs/SUBSCRIBER_ISOLATION_SOLUTION.md
   - docs/ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md
   - DESIGN.md
-workflowType: 'architecture'
 project_name: OmniInspect
 user_name: Basuruk
 date: '2026-04-26'
@@ -44,8 +43,8 @@ _This document builds collaboratively through step-by-step discovery. Sections a
 
 | Decision | Value |
 |----------|-------|
-| Name format | `< 30 chars, `^[A-Za-z_]+$` (letters and underscores only) |
-| Name uniqueness | Use subscriber's existing unique ID (e.g., `SUB_0CC283A4...`) |
+| Name format | `<30 chars`, `^[A-Za-z_]+$` (letters and underscores only) |
+| Name uniqueness | Auto-assigned funny name (e.g., BARNACLE, PICKLES) via FunnyNameGenerator |
 | Creation | Idempotent - check if exists, only create if missing |
 | SQL injection | Strict format validation before DDL generation |
 | Package invalidation | Accepted risk - app redeploys on restart |
@@ -182,7 +181,7 @@ IFS Cloud executes trace calls under IFS app user identity, NOT the debugging Om
 **Decision**: Curated list of ~150 iconic cartoon character names
 
 **Name List**:
-```
+```text
 Mickey, Donald, Goofy, Pluto, Minnie, Daisy, Chip, Dale, Huey, Dewey, Louie,
 Simba, Mufasa, Scar, Nala, Timon, Pumbaa, Zazu,
 Bugs, Daffy, Porky, Tweety, Sylvester, Yosemite, Elmer, Foghorn,
@@ -507,7 +506,7 @@ Service Layer
 ### Integration Points
 
 **Oracle Package (PL/SQL) — External to this codebase:**
-```
+```text
 OMNI_TRACER_API
 ├── Trace_Message(message_, log_level_)      # Original - unchanged
 ├── Enqueue_For_Subscriber(...)             # [NEW] Internal helper for generated procedures
@@ -516,23 +515,6 @@ OMNI_TRACER_API
 
 **Dynamic Deployment Note:**
 Per-subscriber procedures are generated as runtime DDL and executed via `ExecuteStatement()` to add them inside the `OMNI_TRACER_API` package body. This requires ALTER PACKAGE which may invalidate the entire package — this is an accepted risk.
-
-**Data Flow:**
-```
-IFS Cloud → OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg')
-         → Enqueue_For_Subscriber(subscriber_=<NAME>, ...)
-         → AQ Queue
-         → OmniView dequeues
-         → Only matching subscriber receives
-```
-OMNI_TRACER_API
-├── Trace_Message(message_, log_level_)      # Original - unchanged
-├── Enqueue_For_Subscriber(...)             # [NEW] Internal helper for generated procedures
-└── TRACE_MESSAGE_<FUNNY_NAME>(...)        # [NEW] Generated per subscriber
-```
-
-**Dynamic Deployment Note:**
-Per-subscriber procedures are NOT embedded in files. They are generated as runtime DDL strings and executed via `ExecuteStatement()`. This allows dynamic procedure creation without recompiling the Go binary.
 
 **Data Flow:**
 ```

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -1,5 +1,5 @@
 ---
-stepsCompleted: [1, 2]
+stepsCompleted: [1, 2, 3]
 inputDocuments:
   - _bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
   - docs/SUBSCRIBER_ISOLATION_SOLUTION.md
@@ -103,7 +103,31 @@ IFS Cloud executes trace calls under IFS app user identity, NOT the debugging Om
 
 ---
 
+## Starter Template Evaluation
+
+### Primary Technology Domain
+
+**Not Applicable** - This is a brownfield feature enhancement to an existing OmniView/OmniInspect project.
+
+The project already has an established tech stack:
+- **Language**: Go
+- **UI Framework**: Bubble Tea v2 + Lip Gloss v2
+- **Database**: Oracle 19c with ODPI-C
+- **Architecture**: Hexagonal (Ports and Adapters)
+
+No starter template required. Technical decisions are already made by the existing architecture.
+
+### Architectural Approach
+
+For this enhancement, we follow the **extend, not replace** principle:
+- Existing `OMNI_TRACER_API` package → extend with new procedures
+- Existing `SubscriberService` → add procedure generation on registration
+- Existing Settings UI → add danger zone options
+- Existing `TracerService` → remains unchanged (receiving logic unchanged)
+
+---
+
 ## Next Step
 
-[C] Continue to evaluate starter templates
+[C] Continue to architectural decisions
 

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -1,5 +1,9 @@
 ---
-stepsCompleted: [1, 2, 3]
+stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8]
+workflowType: 'architecture'
+lastStep: 8
+status: 'complete'
+completedAt: '2026-04-26'
 inputDocuments:
   - _bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
   - docs/SUBSCRIBER_ISOLATION_SOLUTION.md
@@ -103,6 +107,234 @@ IFS Cloud executes trace calls under IFS app user identity, NOT the debugging Om
 
 ---
 
+## Core Architectural Decisions
+
+### Decision Priority Analysis
+
+**Critical Decisions (Block Implementation):**
+- Procedure naming convention (DECIDED ✅)
+- Procedure generation location (DECIDED ✅)
+- Method name display location (DECIDED ✅)
+- Cartoon character name list (PENDING)
+
+**Important Decisions (Shape Architecture):**
+- None remaining
+
+**Deferred Decisions (Post-MVP):**
+- None
+
+---
+
+### DEC-1: Procedure Naming Convention
+
+**Status**: DECIDED ✅
+
+**Decision**: Auto-assign funny cartoon character names from curated list
+
+**Details**:
+- Curated list of 100+ cartoon character names (Mickey, Donald, Bugs, Daffy, Scooby, Tom, Jerry, etc.)
+- System auto-assigns on subscriber creation
+- User has NO visibility into or choice over the name
+- Collision handling: system picks another available name automatically
+
+**Resulting procedure name**: `TRACE_MESSAGE_<FUNNY_NAME>` (e.g., `TRACE_MESSAGE_BARNACLE`)
+
+**Display in TUI**: `OMNI_TRACER_API.TRACE_MESSAGE_BARNACLE('msg')`
+
+---
+
+### DEC-2: Procedure Generation Location
+
+**Status**: DECIDED ✅
+
+**Decision**: Always generate procedures inside `OMNI_TRACER_API` package
+
+**Details**:
+- Procedures are added to existing package body via ALTER PACKAGE
+- NOT standalone schema objects — all methods must be inside Omni_Tracer_API
+- Package invalidation is acceptable risk — monitor and adjust if it becomes a problem
+- Enables single package to contain all generated methods
+- Simplifies permissions and deployment
+
+**Implementation Note**:
+- `Enqueue_For_Subscriber()` must be added to base package as part of this development
+- Generated procedures call `Enqueue_For_Subscriber()` internally
+
+---
+
+### DEC-3: Method Name Display Location
+
+**Status**: DECIDED ✅
+
+**Decision**: Display in Main Screen header with visual indication
+
+**Details**:
+- User always sees their method name in the Main Screen header/status area
+- Visual indication to draw attention to it
+- Shows the exact procedure they must call in their PL/SQL code
+
+---
+
+### DEC-4: Cartoon Character Name List
+
+**Status**: DECIDED ✅
+
+**Decision**: Curated list of ~150 iconic cartoon character names
+
+**Name List**:
+```
+Mickey, Donald, Goofy, Pluto, Minnie, Daisy, Chip, Dale, Huey, Dewey, Louie,
+Simba, Mufasa, Scar, Nala, Timon, Pumbaa, Zazu,
+Bugs, Daffy, Porky, Tweety, Sylvester, Yosemite, Elmer, Foghorn,
+Tom, Jerry, Spike, Butch, Tuffy,
+Scooby, Shaggy, Fred, Daphne, Velma,
+SpongeBob, Patrick, Squidward, Krabs, Sandy, Gary,
+Woody, Buzz, Jessie, Rex, Slinky, Hamm, Bo,
+Mike, Sulley, Randall, Celia, Roz,
+Marlin, Nemo, Dory, Gill, Bloat, Bubbles, Peach,
+Stitch, Lilo, Jumba, Pleakley, Gantu,
+Aladdin, Jasmine, Genie, Abu, Jafar, Sultan, Iago,
+Belle, Beast, Gaston, Lumière, Cogsworth, MrsPotts, Chip,
+Peter, Wendy, Michael, Tinker, Nana,
+Hercules, Meg, Pegasus, Phil,
+Mulan, Mushu, LiShan, ShanYu,
+Tarzan, Jane, Clayton,
+Ariel, Sebastian, Flounder, Ursula, Triton,
+Cinderella, Jaq, Gus, FairyGodmother,
+SleepingBeauty, Maleficent, Flora, Fauna, Merryweather,
+SnowWhite, EvilQueen, Grumpy, Happy, Bashful, Sneezy, Dopey, Doc,
+Pinocchio, Jiminy, Geppetto, BlueFairy,
+RobinHood, LittleJohn, MaidMarian, Sheriff,
+PeterPan, CaptainHook, TinkerBell,
+Alice, MadHatter, CheshireCat, QueenOfHearts,
+Winnie, Piglet, Eeyore, Tigger, Rabbit, Owl, Kanga, Roo,
+Sonic, Tails, Knuckles, Amy, Shadow, Silver, Blaze,
+Mario, Luigi, Peach, Toad, Yoshi, Bowser, Koopa,
+Bart, Homer, Marge, Lisa, Maggie, Flanders,
+FamilyGuy, Stewie, Brian,
+SouthPark, Stan, Kyle, Cartman, Kenny,
+Rick, Morty, Summer, Beth, Jerry, Squanchy,
+Yoda, Luke, Leia, Han, Vader, Chewbacca,
+Batman, Superman, WonderWoman,
+Gadget, Monterey, Zipper, Pikachu, Ash, Misty, Brock,
+Goku, Vegeta, Piccolo, Gohan, Frieza, Cell,
+Naruto, Sasuke, Sakura, Kakashi, Hinata,
+Luffy, Zoro, Nami, Usopp, Sanji, Chopper,
+Guts, Griffith, Casca, Farnese, Serpico
+```
+
+**Validation**: All names match `^[A-Za-z_]+$` (letters and underscores only, no numbers)
+
+---
+
+### DEC-5: Cartoon Name List Storage
+
+**Status**: DECIDED ✅
+
+**Decision**: Store as Go constant array in `internal/core/domain/funny_names.go`
+
+**Rationale**: Domain layer - fits the value object pattern; follows existing project conventions
+
+---
+
+## Implementation Patterns & Consistency Rules
+
+### Existing Patterns (From AGENTS.md & DESIGN.md)
+
+The following patterns are already established and MUST be followed:
+
+| Document | Patterns |
+|----------|----------|
+| `AGENTS.md` | Constructor `New...`, Interfaces `...er`, Package naming, Error handling, Hexagonal architecture |
+| `DESIGN.md` | Bubble Tea v2 lifecycle, Lip Gloss styling, Component standards, Interaction rules |
+| `internal/core/domain/` | Entity pattern, Value objects, Sentinel errors |
+
+### New Patterns for Multi-Subscriber Feature
+
+#### Pattern 1: Funny Name Assignment
+
+**File**: `internal/core/domain/funny_names.go`
+
+```go
+// FunnyNames returns the curated list of cartoon character names
+// for subscriber procedure naming.
+func FunnyNames() []string {
+    return []string{
+        "Mickey", "Donald", "Goofy", // ... (full list)
+    }
+}
+
+// ValidateName returns true if name is in the funny names list.
+// Used for SQL injection prevention - names MUST come from this list.
+func IsValidFunnyName(name string) bool {
+    // ... lookup in list
+}
+```
+
+#### Pattern 2: Procedure Generation Method
+
+**File**: `internal/service/subscriber/` (subscriber_service.go)
+
+```go
+// GenerateSubscriberProcedure generates the TRACE_MESSAGE_<name> procedure
+// inside the OMNI_TRACER_API package.
+func (s *SubscriberService) GenerateSubscriberProcedure(ctx context.Context, subscriberName string) error
+
+// DropSubscriberProcedure removes the subscriber's procedure from the package.
+func (s *SubscriberService) DropSubscriberProcedure(ctx context.Context, subscriberName string) error
+
+// DropAllProcedures drops the entire OMNI_TRACER_API package.
+func (s *SubscriberService) DropAllProcedures(ctx context.Context) error
+```
+
+#### Pattern 3: Dynamic PL/SQL Generation
+
+**DDL Format** (procedure added to existing package body via ALTER PACKAGE):
+
+```sql
+-- Pattern for generated procedure within package body:
+PROCEDURE TRACE_MESSAGE_BARNACLE(
+    message_   IN VARCHAR2,
+    log_level_ IN VARCHAR2 DEFAULT 'INFO'
+)
+IS
+BEGIN
+    OMNI_TRACER_API.Enqueue_For_Subscriber(
+        subscriber_name_ => 'BARNACLE',
+        message_         => message_,
+        log_level_       => log_level_
+    );
+END TRACE_MESSAGE_BARNACLE;
+```
+
+**Required Prerequisite**: `Enqueue_For_Subscriber()` must exist in `OMNI_TRACER_API` package before generated procedures can call it.
+
+**Validation Rules**:
+- Name MUST be validated against funny name list before DDL generation
+- No user-provided names accepted - only system-assigned funny names
+- Format check: `^[A-Za-z_]+$` before any DDL execution
+- Idempotent: Check procedure exists before creating (skip if already exists)
+
+#### Pattern 4: Settings UI Danger Zone
+
+**File**: `internal/adapter/ui/database_settings.go`
+
+Danger zone section in Settings screen:
+- Visual distinction (red/warning styling)
+- Confirmation required before destructive actions
+- Two options: Drop subscriber procedure OR Drop entire package
+
+### Enforcement Guidelines
+
+**All AI Agents MUST**:
+- Follow existing patterns from `AGENTS.md` and `DESIGN.md`
+- Store funny name list in `internal/core/domain/funny_names.go`
+- Use idempotent procedure creation (check if exists before creating)
+- Implement proper error handling for package invalidation scenarios
+- Follow Lip Gloss styling from DESIGN.md for new UI elements
+
+---
+
 ## Starter Template Evaluation
 
 ### Primary Technology Domain
@@ -127,7 +359,295 @@ For this enhancement, we follow the **extend, not replace** principle:
 
 ---
 
+## Project Structure & Boundaries
+
+### Complete Project Directory Structure
+
+```
+OmniInspect/
+├── AGENTS.md                                    # Agent guidelines & patterns
+├── Makefile                                     # Build commands
+├── DESIGN.md                                   # UX design specification
+├── README.md
+├── go.mod
+├── go.sum
+├── cmd/
+│   └── omniview/
+│       └── main.go                              # Composition root
+│
+├── internal/
+│   ├── adapter/
+│   │   ├── config/                             # Settings loader
+│   │   ├── storage/
+│   │   │   ├── boltdb/                         # BoltDB implementation
+│   │   │   └── oracle/
+│   │   │       ├── oracle_adapter.go           # [MODIFY] DDL execution
+│   │   │       ├── dequeue_ops.c               # CGO dequeue operations
+│   │   │       ├── dequeue_ops.h
+│   │   │       ├── queue.go
+│   │   │       ├── sql_parse.go
+│   │   │       └── subscriptions.go
+│   │   └── ui/
+│   │       ├── model.go                        # Bubble Tea model
+│   │       ├── messages.go                     # Message handlers
+│   │       ├── main_screen.go                  # [MODIFY] Display procedure name
+│   │       ├── database_settings.go            # [MODIFY] Danger zone options
+│   │       ├── welcome.go
+│   │       ├── chrome.go
+│   │       ├── loading.go
+│   │       ├── styles/
+│   │       └── animations/
+│   │
+│   ├── core/
+│   │   ├── domain/
+│   │   │   ├── errors.go                       # Sentinel errors
+│   │   │   ├── subscriber.go                   # Subscriber entity
+│   │   │   ├── queue_message.go                 # Queue message entity
+│   │   │   ├── config.go                      # Configuration values
+│   │   │   ├── permissions.go                  # Permission definitions
+│   │   │   ├── webhook.go                      # Webhook configuration
+│   │   │   ├── database_settings.go             # Database settings
+│   │   │   └── funny_names.go                  # [NEW] Cartoon character names
+│   │   │
+│   │   └── ports/
+│   │       └── repository.go                   # Interface definitions
+│   │
+│   ├── service/
+│   │   ├── subscribers/
+│   │   │   └── subscriber_service.go            # [MODIFY] Procedure generation
+│   │   ├── tracer/
+│   │   │   └── tracer_service.go                # Trace event handling
+│   │   ├── permissions/
+│   │   ├── webhook/
+│   │   └── updater/
+│   │
+│   ├── app/
+│   └── updater/
+│
+├── docs/
+│   ├── ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md
+│   ├── SUBSCRIBER_ISOLATION_SOLUTION.md
+│   └── BLOCKING_DEQUEUE_IMPLEMENTATION.md
+│
+└── _bmad-output/
+    ├── planning-artifacts/
+    │   └── architecture.md                     # This document
+    └── brainstorming/
+        └── brainstorming-session-2026-04-19-2221.md
+```
+
+### Architectural Boundaries
+
+**Component Boundaries:**
+```
+Composition Root (cmd/omniview/main.go)
+         │
+         ▼
+Service Layer
+ ┌──────────────────┐  ┌──────────────────┐  ┌──────────────┐
+ │SubscriberService│  │ TracerService    │  │ Permissions  │
+ │ [MODIFY]        │  │                  │  │              │
+ │ - GenerateProc  │  │ - EventListener  │  │              │
+ │ - DropProc      │  │ - MessageHandle │  │              │
+ │ - DropAll       │  │                  │  │              │
+ └──────────────────┘  └──────────────────┘  └──────────────┘
+         │
+    ┌────┴────────┐
+    ▼             ▼
+ Ports      Adapters
+(Interfaces)  ┌─────────────┐  ┌───────────────┐
+              │   Oracle   │  │   BoltDB      │
+              │ [MODIFY]  │  │               │
+              │ - DDL Exec│  │               │
+              └───────────┘  └───────────────┘
+              ┌─────────────────────────────────┐
+              │         UI (Bubble Tea)          │
+              │  ┌────────────┐ ┌────────────┐   │
+              │  │MainScreen │ │DB Settings│   │
+              │  │[MODIFY]   │ │[MODIFY]   │   │
+              │  └────────────┘ └────────────┘   │
+              └─────────────────────────────────┘
+```
+
+**Domain Layer:**
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Domain Layer                              │
+│  ┌────────────────┐  ┌────────────────┐  ┌───────────────┐  │
+│  │   Subscriber   │  │ QueueMessage  │  │ FunnyNames   │  │
+│  │   Entity      │  │   Entity      │  │ [NEW]        │  │
+│  └────────────────┘  └────────────────┘  └───────────────┘  │
+│  ┌────────────────┐  ┌────────────────┐                    │
+│  │    Errors      │  │   Config      │                    │
+│  │  Sentinel     │  │  ValueObject  │                    │
+│  └────────────────┘  └────────────────┘                    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Requirements to Structure Mapping
+
+| Requirement | Files | Changes |
+|-------------|-------|---------|
+| **FR-1, FR-2, FR-6**: Generate `TRACE_MESSAGE_<funny>` procedure | `internal/core/domain/funny_names.go` | **NEW** - Curated name list + validation |
+| | `internal/service/subscribers/subscriber_service.go` | **MODIFY** - Add `GenerateSubscriberProcedure()` |
+| | `internal/adapter/storage/oracle/oracle_adapter.go` | **MODIFY** - Add DDL execution for procedure creation |
+| **FR-3, FR-4**: Danger zone options | `internal/adapter/ui/database_settings.go` | **MODIFY** - Add "Drop my procedure" + "Drop all procedures" |
+| **FR-5**: Auto-redeploy on startup | `internal/adapter/storage/oracle/oracle_adapter.go` | **VERIFY** - Check existing redeploy logic |
+| **FR-7**: Display method name in TUI | `internal/adapter/ui/main_screen.go` | **MODIFY** - Show `OMNI_TRACER_API.TRACE_MESSAGE_<NAME>()` in header |
+
+### Cross-Cutting Concerns Mapping
+
+| Concern | Location |
+|---------|----------|
+| **SQL Injection Prevention** | `internal/core/domain/funny_names.go` - `IsValidFunnyName()` |
+| **Package Invalidation Recovery** | `internal/adapter/storage/oracle/oracle_adapter.go` - existing redeploy |
+| **Error Handling** | `internal/core/domain/errors.go` - add sentinel errors for procedure ops |
+| **CGO/Oracle Alignment** | `dequeue_ops.c` ↔ `dequeue_ops.h` ↔ `oracle_adapter.go` |
+
+### Integration Points
+
+**Oracle Package (PL/SQL) — External to this codebase:**
+```
+OMNI_TRACER_API
+├── Trace_Message(message_, log_level_)      # Original - unchanged
+├── Enqueue_For_Subscriber(...)             # [NEW] Internal helper for generated procedures
+└── TRACE_MESSAGE_<FUNNY_NAME>(...)        # [NEW] Generated per subscriber
+```
+
+**Dynamic Deployment Note:**
+Per-subscriber procedures are generated as runtime DDL and executed via `ExecuteStatement()` to add them inside the `OMNI_TRACER_API` package body. This requires ALTER PACKAGE which may invalidate the entire package — this is an accepted risk.
+
+**Data Flow:**
+```
+IFS Cloud → OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg')
+         → Enqueue_For_Subscriber(subscriber_=<NAME>, ...)
+         → AQ Queue
+         → OmniView dequeues
+         → Only matching subscriber receives
+```
+OMNI_TRACER_API
+├── Trace_Message(message_, log_level_)      # Original - unchanged
+├── Enqueue_For_Subscriber(...)             # [NEW] Internal helper for generated procedures
+└── TRACE_MESSAGE_<FUNNY_NAME>(...)        # [NEW] Generated per subscriber
+```
+
+**Dynamic Deployment Note:**
+Per-subscriber procedures are NOT embedded in files. They are generated as runtime DDL strings and executed via `ExecuteStatement()`. This allows dynamic procedure creation without recompiling the Go binary.
+
+**Data Flow:**
+```
+IFS Cloud → OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg')
+         → Enqueue_For_Subscriber(subscriber_=<NAME>, ...)
+         → AQ Queue
+         → OmniView dequeues
+         → Only matching subscriber receives
+```
+
+---
+
+## Architecture Validation Results
+
+### Coherence Validation ✅
+
+**Decision Compatibility:** All decisions work together:
+- Funny name format `^[A-Za-z_]+$` aligns with SQL injection prevention via `IsValidFunnyName()`
+- Idempotent creation pattern works with `ExecuteStatement()` for DDL
+- Package invalidation risk is explicitly accepted — monitor and adjust if needed
+- All methods inside `OMNI_TRACER_API` package (no standalone schema objects)
+
+**Pattern Consistency:** Implementation patterns support decisions:
+- `funny_names.go` value object pattern matches existing domain layer conventions
+- `subscriber_service.go` modification pattern follows established service patterns
+- Dynamic DDL via `ExecuteStatement()` enables runtime procedure generation
+
+**Structure Alignment:** Project structure supports architecture:
+- `funny_names.go` in `core/domain` as planned
+- `subscriber_service.go` modifications in existing location
+- Oracle adapter has `ExecuteStatement()` already
+
+---
+
+### Requirements Coverage Validation ✅
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| FR-1, FR-2, FR-6: Generate procedure | ✅ | `ExecuteStatement()` at runtime DDL |
+| FR-3, FR-4: Danger zone options | ✅ | `database_settings.go` modification |
+| FR-5: Auto-redeploy | ✅ | Existing `DeployAndCheck()` |
+| FR-7: Display method name | ✅ | `main_screen.go` header area |
+
+**Additional Requirements (User-Confirmed):**
+1. `Enqueue_For_Subscriber()` must be implemented as part of this development
+2. All generated procedures must be inside `OMNI_TRACER_API` package — no standalone schema objects
+3. Package invalidation is accepted risk
+
+---
+
+### Implementation Readiness Validation ✅
+
+**Decision Completeness:** All decisions documented with examples
+**Structure Completeness:** Complete directory tree with `[MODIFY]/[NEW]` annotations
+**Pattern Completeness:** All major patterns have code examples
+
+---
+
+### Gap Analysis Results
+
+**Critical Gaps:** None remaining after user decisions
+
+**Resolved:**
+- `Enqueue_For_Subscriber()` will be added to base package during implementation
+- All procedures inside package (no standalone procedures)
+- Package invalidation accepted risk
+
+---
+
+### Architecture Completeness Checklist
+
+**✅ Requirements Analysis**
+- [x] Project context thoroughly analyzed
+- [x] Scale and complexity assessed
+- [x] Technical constraints identified
+- [x] Cross-cutting concerns mapped
+
+**✅ Architectural Decisions**
+- [x] Critical decisions documented
+- [x] Technology stack fully specified
+- [x] Integration patterns defined
+- [x] Package invalidation risk accepted
+
+**✅ Implementation Patterns**
+- [x] Naming conventions established
+- [x] Structure patterns defined
+- [x] Communication patterns specified
+- [x] Process patterns documented
+
+**✅ Project Structure**
+- [x] Complete directory structure defined
+- [x] Component boundaries established
+- [x] Integration points mapped
+- [x] Requirements to structure mapping complete
+
+---
+
+### Architecture Readiness Assessment
+
+**Overall Status:** READY FOR IMPLEMENTATION
+
+**Confidence Level:** High — all critical decisions made, patterns documented
+
+**Key Decisions Resolved:**
+- Procedure naming: Funny cartoon character names (auto-assigned)
+- Generation approach: Inside `OMNI_TRACER_API` package via ALTER PACKAGE
+- `Enqueue_For_Subscriber()`: Must be added to base package
+- Package invalidation: Accepted risk
+
+**First Implementation Priority:**
+`funny_names.go` (domain value object) → `Enqueue_For_Subscriber()` (base package addition) → procedure generation in `subscriber_service.go`
+
+---
+
 ## Next Step
 
-[C] Continue to architectural decisions
+[C] Continue to complete the architecture workflow
 

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1,5 +1,6 @@
 ---
-stepsCompleted: [1]
+stepsCompleted: [1, 2, 3, 4]
+status: 'complete'
 inputDocuments:
   - _bmad-output/planning-artifacts/architecture.md
   - _bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
@@ -81,7 +82,23 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 ## Epic List
 
-<!-- Placeholder for epic structure -->
+### Epic 1: Multi-Subscriber Procedure Generation
+
+**User Outcome:** IFS developers can call subscriber-specific procedures that route messages to only their OmniView instance.
+
+**FRs Covered:** FR-1, FR-2, FR-5, FR-6
+
+### Epic 2: TUI Procedure Name Display
+
+**User Outcome:** Developers can see exactly which PL/SQL procedure to call in their code.
+
+**FRs Covered:** FR-7
+
+### Epic 3: Danger Zone Implementation
+
+**User Outcome:** Subscribers can clean up their procedures or the entire package when needed.
+
+**FRs Covered:** FR-3, FR-4
 
 ## Epic 1: Multi-Subscriber Procedure Generation
 

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1,0 +1,234 @@
+---
+stepsCompleted: [1]
+inputDocuments:
+  - _bmad-output/planning-artifacts/architecture.md
+  - _bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md
+  - docs/ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md
+  - docs/SUBSCRIBER_ISOLATION_SOLUTION.md
+  - DESIGN.md
+workflowType: 'epics-and-stories'
+project_name: OmniInspect
+user_name: Basuruk
+date: '2026-04-27'
+---
+
+# OmniInspect - Epic Breakdown
+
+## Overview
+
+This document provides the complete epic and story breakdown for OmniInspect, decomposing the requirements from the Architecture and design decisions into implementable stories.
+
+## Requirements Inventory
+
+### Functional Requirements
+
+**FR-1:** Generate unique `TRACE_MESSAGE_<subscriber_id>()` procedure per subscriber on registration
+
+**FR-2:** Idempotent creation - check if procedure exists before creating
+
+**FR-3:** Modify Settings UI - Add danger zone option to drop subscriber-specific procedure
+
+**FR-4:** Modify Settings UI - Add danger zone option to drop entire OMNI_TRACER_API package
+
+**FR-5:** Auto-redeploy package on startup if missing
+
+**FR-6:** Strict name format validation (`^[A-Za-z_]+$`) to prevent SQL injection
+
+**FR-7:** Display the subscriber's method name in TUI - Show the user the exact procedure they must call in their PL/SQL code to receive subscriber-isolated messages (e.g., `OMNI_TRACER_API.TRACE_MESSAGE_SUB_0CC283A4...`)
+
+### NonFunctional Requirements
+
+**NFR-1:** Package invalidation is acceptable - app recovers on restart
+
+**NFR-2:** Any database user can call generated procedures
+
+**NFR-3:** Support N concurrent subscribers (no hard limit)
+
+**NFR-4:** Developer ergonomics - `TRACE_MESSAGE_xxx('msg')` same friction as `Trace_Message('msg')`
+
+### Additional Requirements
+
+- **Funny Name System:** Auto-assign curated cartoon character names (e.g., Mickey, Donald, Bugs, Daffy, Scooby, Tom, Jerry) to subscribers for procedure naming
+- **Name Collision Handling:** System automatically picks another available name if collision occurs
+- **Enqueue_For_Subscriber():** Must be added to base OMNI_TRACER_API package as prerequisite for generated procedures
+- **SQL Injection Prevention:** Strict format validation on all funny names before DDL generation
+- **Idempotent Procedure Creation:** Check if procedure exists before creating (skip if already exists)
+- **Backwards Compatibility:** Existing `Trace_Message()` callers remain unaffected
+
+### UX Design Requirements
+
+**UX-DR1:** Display subscriber's procedure name (`OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg')`) in Main Screen header with visual emphasis
+
+**UX-DR2:** Add danger zone section in Settings screen with:
+- Clear visual distinction (red/warning styling)
+- Confirmation required before destructive actions
+- Option to drop subscriber-specific procedure
+- Option to drop entire OMNI_TRACER_API package
+
+**UX-DR3:** Settings screen keyboard shortcut (S key) already implemented - verify danger zone integration works correctly
+
+### FR Coverage Map
+
+| FR | Description | Epic |
+|----|-------------|------|
+| FR-1 | Generate TRACE_MESSAGE_<id>() procedure per subscriber | Epic 1 |
+| FR-2 | Idempotent creation | Epic 1 |
+| FR-3 | Drop subscriber-specific procedure | Epic 3 |
+| FR-4 | Drop entire OMNI_TRACER_API package | Epic 3 |
+| FR-5 | Auto-redeploy on startup | Epic 1 |
+| FR-6 | Strict name format validation | Epic 1 |
+| FR-7 | Display procedure name in TUI | Epic 2 |
+
+## Epic List
+
+<!-- Placeholder for epic structure -->
+
+## Epic 1: Multi-Subscriber Procedure Generation
+
+### Epic Goal
+
+Implement dynamic procedure generation system that creates per-subscriber `TRACE_MESSAGE_<name>()` procedures inside the OMNI_TRACER_API package, enabling message isolation between subscribers.
+
+## Epic 2: TUI Procedure Name Display
+
+### Epic Goal
+
+Display each subscriber's unique procedure name in the TUI header, making it easy for developers to know exactly which PL/SQL procedure to call.
+
+## Epic 3: Danger Zone Implementation
+
+### Epic Goal
+
+Add Settings UI options for subscribers to clean up their procedure or drop the entire OMNI_TRACER_API package.
+
+<!-- Repeat for each story (M = 1, 2, 3...) within epic N -->
+
+### Story 1.1: Funny Name Value Object
+
+As a system,
+I want to auto-assign funny cartoon character names to subscribers,
+So that procedure names are memorable and unique.
+
+**Acceptance Criteria:**
+
+**Given** a new subscriber registers with OmniView
+**When** the system generates their procedure
+**Then** a funny name (e.g., BARNACLE, PICKLES, NIBBLES) is automatically assigned from the curated list
+**And** the resulting procedure is `OMNI_TRACER_API.TRACE_MESSAGE_BARNACLE('msg')`
+
+**Given** a funny name is already assigned to another subscriber
+**When** a new subscriber registers
+**Then** the system picks another available name to avoid collision
+**And** no two subscribers have the same procedure name
+
+---
+
+### Story 1.2: Procedure Generation with Enqueue_For_Subscriber
+
+As a system,
+I want to generate `TRACE_MESSAGE_<name>()` procedures that call `Enqueue_For_Subscriber()`,
+So that messages are routed to the correct subscriber.
+
+**Acceptance Criteria:**
+
+**Given** a subscriber with name BARNACLE is registered
+**When** OmniView generates their procedure
+**Then** the procedure `TRACE_MESSAGE_BARNACLE(message_, log_level_)` is created inside OMNI_TRACER_API package
+**And** it calls `OMNI_TRACER_API.Enqueue_For_Subscriber(subscriber_name_ => 'BARNACLE', message_ => message_, log_level_ => log_level_)`
+
+**Given** the subscriber's procedure already exists
+**When** OmniView starts
+**Then** no new procedure is created (idempotent)
+
+---
+
+### Story 1.3: SQL Injection Prevention
+
+As a system,
+I want to validate all funny names against a strict format before DDL generation,
+So that SQL injection attacks are prevented.
+
+**Acceptance Criteria:**
+
+**Given** a name from the funny name list
+**When** validation runs
+**Then** it passes if it matches `^[A-Za-z_]+$` (letters and underscores only)
+**And** it fails if it contains numbers, special characters, or spaces
+
+**Given** an invalid name somehow reaches the DDL generator
+**When** the system attempts to create a procedure
+**Then** an error is returned and no procedure is created
+
+---
+
+### Story 1.4: Auto-Deploy Package on Startup
+
+As a system,
+I want to check if OMNI_TRACER_API package exists on startup,
+So that I can redeploy it if missing.
+
+**Acceptance Criteria:**
+
+**Given** OmniView starts
+**When** the system checks for OMNI_TRACER_API package
+**Then** if missing, it deploys the base package with `Enqueue_For_Subscriber()`
+**And** it then generates all subscriber procedures
+
+**Given** OmniView starts and OMNI_TRACER_API package exists
+**When** the system checks
+**Then** it skips deployment and uses existing package
+**And** it generates any missing subscriber procedures
+
+---
+
+### Story 2.1: Display Procedure Name in Header
+
+As an IFS developer,
+I want to see my procedure name in the OmniView header,
+So that I know exactly which PL/SQL to call in my code.
+
+**Acceptance Criteria:**
+
+**Given** a subscriber named BARNACLE is registered
+**When** the Main Screen displays
+**Then** the header shows `OMNI_TRACER_API.TRACE_MESSAGE_BARNACLE('msg')`
+**And** the name is visually prominent (e.g., different color, bold)
+
+---
+
+### Story 3.1: Drop Subscriber Procedure (Danger Zone)
+
+As a subscriber,
+I want to delete my specific procedure,
+So that I can clean up when I no longer need tracing.
+
+**Acceptance Criteria:**
+
+**Given** the subscriber is on the Settings screen
+**When** they select "Delete My Procedure"
+**Then** a confirmation dialog appears warning this action
+**And** if confirmed, the `TRACE_MESSAGE_<name>()` procedure is removed from OMNI_TRACER_API package
+
+**Given** the procedure is deleted
+**When** OmniView restarts
+**Then** if the subscriber is still registered, the procedure is regenerated
+
+---
+
+### Story 3.2: Drop Entire Package (Danger Zone)
+
+As a subscriber,
+I want to drop the entire OMNI_TRACER_API package,
+So that I can remove all generated procedures at once.
+
+**Acceptance Criteria:**
+
+**Given** the subscriber is on the Settings screen
+**When** they select "Drop All Procedures"
+**Then** a confirmation dialog appears with strong warning
+**And** if confirmed, the entire OMNI_TRACER_API package is dropped from the database
+
+**Given** the package is dropped
+**When** OmniView restarts
+**Then** it redeploys the base package with `Enqueue_For_Subscriber()`
+**And** it regenerates all subscriber procedures

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -23,9 +23,9 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 ### Functional Requirements
 
-**FR-1:** Generate unique `TRACE_MESSAGE_<subscriber_id>()` procedure per subscriber on registration
+**FR-1:** Generate unique `TRACE_MESSAGE_<FUNNY_NAME>()` procedure per subscriber on registration using auto-assigned funny names (e.g., BARNACLE, PICKLES)
 
-**FR-2:** Idempotent creation - check if procedure exists before creating
+**FR-2:** Idempotent creation - check if procedure exists (by funny name) before creating
 
 **FR-3:** Modify Settings UI - Add danger zone option to drop subscriber-specific procedure
 
@@ -35,7 +35,7 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 **FR-6:** Strict name format validation (`^[A-Za-z_]+$`) to prevent SQL injection
 
-**FR-7:** Display the subscriber's method name in TUI - Show the user the exact procedure they must call in their PL/SQL code to receive subscriber-isolated messages (e.g., `OMNI_TRACER_API.TRACE_MESSAGE_SUB_0CC283A4...`)
+**FR-7:** Display the subscriber's method name in TUI - Show the user the exact procedure they must call in their PL/SQL code to receive subscriber-isolated messages (e.g., `OMNI_TRACER_API.TRACE_MESSAGE_BARNACLE('msg')`)
 
 ### NonFunctional Requirements
 
@@ -45,7 +45,7 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 **NFR-3:** Support N concurrent subscribers (no hard limit)
 
-**NFR-4:** Developer ergonomics - `TRACE_MESSAGE_xxx('msg')` same friction as `Trace_Message('msg')`
+**NFR-4:** Developer ergonomics - `TRACE_MESSAGE_BARNACLE('msg')` same friction as `Trace_Message('msg')`
 
 ### Additional Requirements
 
@@ -72,7 +72,7 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 | FR | Description | Epic |
 |----|-------------|------|
-| FR-1 | Generate TRACE_MESSAGE_<id>() procedure per subscriber | Epic 1 |
+| FR-1 | Generate TRACE_MESSAGE_<FUNNY_NAME>() procedure per subscriber | Epic 1 |
 | FR-2 | Idempotent creation | Epic 1 |
 | FR-3 | Drop subscriber-specific procedure | Epic 3 |
 | FR-4 | Drop entire OMNI_TRACER_API package | Epic 3 |
@@ -104,7 +104,7 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 ### Epic Goal
 
-Implement dynamic procedure generation system that creates per-subscriber `TRACE_MESSAGE_<name>()` procedures inside the OMNI_TRACER_API package, enabling message isolation between subscribers.
+Implement dynamic procedure generation system that creates per-subscriber `TRACE_MESSAGE_<FUNNY_NAME>()` procedures inside the OMNI_TRACER_API package, enabling message isolation between subscribers using auto-assigned funny names.
 
 ## Epic 2: TUI Procedure Name Display
 
@@ -143,7 +143,7 @@ So that procedure names are memorable and unique.
 ### Story 1.2: Procedure Generation with Enqueue_For_Subscriber
 
 As a system,
-I want to generate `TRACE_MESSAGE_<name>()` procedures that call `Enqueue_For_Subscriber()`,
+I want to generate `TRACE_MESSAGE_<FUNNY_NAME>()` procedures that call `Enqueue_For_Subscriber()`, using the subscriber's auto-assigned funny name.
 So that messages are routed to the correct subscriber.
 
 **Acceptance Criteria:**
@@ -224,7 +224,7 @@ So that I can clean up when I no longer need tracing.
 **Given** the subscriber is on the Settings screen
 **When** they select "Delete My Procedure"
 **Then** a confirmation dialog appears warning this action
-**And** if confirmed, the `TRACE_MESSAGE_<name>()` procedure is removed from OMNI_TRACER_API package
+**And** if confirmed, the `TRACE_MESSAGE_<FUNNY_NAME>()` procedure is removed from OMNI_TRACER_API package
 
 **Given** the procedure is deleted
 **When** OmniView restarts

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -33,7 +33,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 
 - Follow existing Go constructor patterns: `New...` functions validate inputs and usually return pointers.
 - Keep domain entities validated and infrastructure-agnostic; prefer private struct fields with read-only methods instead of exposing mutable state.
-- Use sentinel domain errors from `internal/core/domain/errors.go` and wrap with context via `fmt.Errorf("operation: %w", err)`.
+- Use sentinel domain errors from `internal/core/domain/errors.go` and wrap with context via `fmt.Errorf("operation: %w", err)`. Domain sentinel errors (like `ErrInvalidFunnyName`, `ErrNoAvailableNames`) live in `errors.go` alongside other domain errors — not in feature-specific files.
 - Prefer pointer receivers for services, adapters, and Bubble Tea models that own mutable state.
 - Inject dependencies through constructor arguments or option structs; do not instantiate cross-layer dependencies inside adapters or services.
 - Keep nil checks explicit at construction boundaries for required collaborators.

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -13,6 +13,10 @@ var (
 	ErrSubscriberNotActive   = errors.New("subscriber is not active")
 	ErrInvalidBatchSize      = errors.New("invalid batch size")
 	ErrInvalidWaitTime       = errors.New("invalid wait time")
+	ErrInvalidFunnyName      = errors.New("invalid funny name")
+	ErrNoAvailableNames      = errors.New("no available funny names")
+	ErrFunnyNameTooLong      = errors.New("funny name exceeds maximum length")
+	ErrFunnyNameTooShort     = errors.New("funny name too short")
 	ErrNilSubscriber         = errors.New("nil subscriber")
 	ErrTracerNotInitialized  = errors.New("tracer service not initialized")
 

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -9,8 +9,10 @@ import (
 
 const (
 	MinFunnyNameLength = 3
-	MaxFunnyNameLength = 20
-	FunnyNamePattern   = `^[A-Za-z_]+$`
+	MaxFunnyNameLength = 30
+	// FunnyNamePattern is the regex pattern for valid funny names.
+	// Format: ^[A-Za-z_]+$ — letters and underscores only, no digits.
+	FunnyNamePattern = `^[A-Za-z_]+$`
 )
 
 type FunnyName struct {
@@ -20,10 +22,10 @@ type FunnyName struct {
 // NewFunnyName creates a validated funny-name value object.
 func NewFunnyName(name string) (FunnyName, error) {
 	if err := ValidateFunnyNameFormat(name); err != nil {
-		return FunnyName{}, err
+		return FunnyName{}, fmt.Errorf("NewFunnyName: %w", err)
 	}
 	if !isFunnyNameInList(name) {
-		return FunnyName{}, ErrInvalidFunnyName
+		return FunnyName{}, fmt.Errorf("NewFunnyName: %w", ErrInvalidFunnyName)
 	}
 	return FunnyName{name: name}, nil
 }

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -61,7 +61,6 @@ func (f FunnyName) IsValid() bool {
 type funnyNameEntry struct {
 	funnyName FunnyName
 	used      bool
-	index     int
 }
 
 type FunnyNameGenerator struct {
@@ -91,7 +90,7 @@ func newFunnyNameGenerator(seed int64) *FunnyNameGenerator {
 		if err != nil {
 			panic(fmt.Sprintf("initialize funny name generator: %v", err))
 		}
-		names[i] = funnyNameEntry{funnyName: funnyName, index: i}
+		names[i] = funnyNameEntry{funnyName: funnyName}
 	}
 	src := rand.NewSource(seed)
 	return &FunnyNameGenerator{

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -90,29 +90,43 @@ func (g *FunnyNameGenerator) IsUsed(name string) bool {
 }
 
 // MarkAsUsed marks the given funny name as used so it won't be returned by GetRandomName.
-func (g *FunnyNameGenerator) MarkAsUsed(name string) {
+// Returns an error if the name is empty, whitespace-only, or not found in the curated list.
+func (g *FunnyNameGenerator) MarkAsUsed(name string) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.used[strings.ToUpper(name)] = true
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("mark funny name as used: %w", ErrInvalidFunnyName)
+	}
+	upper := strings.ToUpper(trimmed)
 	for i := range g.names {
-		if strings.EqualFold(g.names[i].name, name) {
+		if g.names[i].name == upper {
 			g.names[i].used = true
-			break
+			g.used[upper] = true
+			return nil
 		}
 	}
+	return fmt.Errorf("mark funny name as used: %w", ErrInvalidFunnyName)
 }
 
 // MarkAsAvailable releases a previously assigned funny name, making it available again.
-func (g *FunnyNameGenerator) MarkAsAvailable(name string) {
+// Returns an error if the name is empty, whitespace-only, or not found in the curated list.
+func (g *FunnyNameGenerator) MarkAsAvailable(name string) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	delete(g.used, strings.ToUpper(name))
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("mark funny name as available: %w", ErrInvalidFunnyName)
+	}
+	upper := strings.ToUpper(trimmed)
 	for i := range g.names {
-		if strings.EqualFold(g.names[i].name, name) {
+		if g.names[i].name == upper {
 			g.names[i].used = false
-			break
+			delete(g.used, upper)
+			return nil
 		}
 	}
+	return fmt.Errorf("mark funny name as available: %w", ErrInvalidFunnyName)
 }
 
 // GetRandomName returns a randomly selected funny name that is currently available.
@@ -328,7 +342,7 @@ var funnyNameList = []string{
 	"Tony",
 	"Tweety",
 	"Tom",
-	"Ty",
+	"Tycho",
 	"Vanilla",
 	"Vinnie",
 	"Waffles",

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -81,16 +81,23 @@ var (
 
 // ==========================================
 // Generator Construction
-// ==========================================
+// ==========================================//
 
+// newFunnyNameGenerator initializes a FunnyNameGenerator with the provided seed.
 func newFunnyNameGenerator(seed int64) *FunnyNameGenerator {
-	names := make([]funnyNameEntry, len(funnyNameList))
-	for i, name := range funnyNameList {
+	seen := make(map[string]bool, len(funnyNameList))
+	names := make([]funnyNameEntry, 0, len(funnyNameList))
+	for _, name := range funnyNameList {
 		funnyName, err := NewFunnyName(strings.ToUpper(name))
 		if err != nil {
 			panic(fmt.Sprintf("initialize funny name generator: %v", err))
 		}
-		names[i] = funnyNameEntry{funnyName: funnyName}
+		upper := funnyName.Name()
+		if seen[upper] {
+			panic(fmt.Sprintf("initialize funny name generator: duplicate name %q in curated list", upper))
+		}
+		seen[upper] = true
+		names = append(names, funnyNameEntry{funnyName: funnyName})
 	}
 	src := rand.NewSource(seed)
 	return &FunnyNameGenerator{
@@ -252,6 +259,7 @@ func IsValidFunnyName(name string) bool {
 	return isFunnyNameInList(name)
 }
 
+// isFunnyNameInList checks if the given name exists in the curated funny name list (case-insensitive).
 func isFunnyNameInList(name string) bool {
 	upper := strings.ToUpper(name)
 	for _, valid := range funnyNameList {

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -1,0 +1,343 @@
+package domain
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+)
+
+const (
+	MinFunnyNameLength = 3
+	MaxFunnyNameLength = 20
+	FunnyNamePattern   = `^[A-Za-z_]+$`
+)
+
+type FunnyName struct {
+	name  string
+	used  bool
+	index int
+}
+
+// String returns the funny name as a string.
+func (f FunnyName) String() string {
+	return f.name
+}
+
+// IsValid returns true if the FunnyName is valid (non-empty and passes funny-name validation).
+func (f FunnyName) IsValid() bool {
+	return IsValidFunnyName(f.name)
+}
+
+type FunnyNameGenerator struct {
+	mu     sync.Mutex
+	names  []FunnyName
+	used   map[string]bool
+	source *rand.Rand
+}
+
+var (
+	defaultGenerator *FunnyNameGenerator
+	once             sync.Once
+)
+
+func newFunnyNameGenerator(seed int64) *FunnyNameGenerator {
+	names := make([]FunnyName, len(funnyNameList))
+	for i, name := range funnyNameList {
+		names[i] = FunnyName{name: strings.ToUpper(name), used: false, index: i}
+	}
+	src := rand.NewSource(seed)
+	return &FunnyNameGenerator{
+		names:  names,
+		used:   make(map[string]bool),
+		source: rand.New(src),
+	}
+}
+
+// DefaultFunnyNameGenerator returns the singleton FunnyNameGenerator instance.
+// The generator is initialized once with a deterministic seed for reproducibility.
+func DefaultFunnyNameGenerator() *FunnyNameGenerator {
+	once.Do(func() {
+		defaultGenerator = newFunnyNameGenerator(42)
+	})
+	return defaultGenerator
+}
+
+// NewFunnyNameGenerator creates a new FunnyNameGenerator with a given random seed.
+// The generator maintains state of used names and provides thread-safe name assignment.
+func NewFunnyNameGenerator(seed int64) *FunnyNameGenerator {
+	return newFunnyNameGenerator(seed)
+}
+
+// AvailableCount returns the number of funny names that are still available (not yet assigned).
+func (g *FunnyNameGenerator) AvailableCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	count := 0
+	for _, fn := range g.names {
+		if !fn.used {
+			count++
+		}
+	}
+	return count
+}
+
+// IsUsed reports whether the given funny name is currently marked as used.
+func (g *FunnyNameGenerator) IsUsed(name string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.used[strings.ToUpper(name)]
+}
+
+// MarkAsUsed marks the given funny name as used so it won't be returned by GetRandomName.
+func (g *FunnyNameGenerator) MarkAsUsed(name string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.used[strings.ToUpper(name)] = true
+	for i := range g.names {
+		if strings.EqualFold(g.names[i].name, name) {
+			g.names[i].used = true
+			break
+		}
+	}
+}
+
+// MarkAsAvailable releases a previously assigned funny name, making it available again.
+func (g *FunnyNameGenerator) MarkAsAvailable(name string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.used, strings.ToUpper(name))
+	for i := range g.names {
+		if strings.EqualFold(g.names[i].name, name) {
+			g.names[i].used = false
+			break
+		}
+	}
+}
+
+// GetRandomName returns a randomly selected funny name that is currently available.
+// Returns ErrNoAvailableNames when all names have been assigned.
+func (g *FunnyNameGenerator) GetRandomName() (string, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	available := make([]int, 0)
+	for i, fn := range g.names {
+		if !fn.used {
+			available = append(available, i)
+		}
+	}
+
+	if len(available) == 0 {
+		return "", ErrNoAvailableNames
+	}
+
+	idx := available[g.source.Intn(len(available))]
+	g.names[idx].used = true
+	g.used[strings.ToUpper(g.names[idx].name)] = true
+
+	return g.names[idx].name, nil
+}
+
+// Reset marks all funny names as available and clears the used set.
+func (g *FunnyNameGenerator) Reset() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for i := range g.names {
+		g.names[i].used = false
+	}
+	g.used = make(map[string]bool)
+}
+
+// ValidateFunnyNameFormat validates that a name conforms to the funny name format.
+// Valid names must be 3-20 characters, contain only letters and underscores, and not be empty.
+func ValidateFunnyNameFormat(name string) error {
+	if name == "" {
+		return ErrInvalidFunnyName
+	}
+	if len(name) < MinFunnyNameLength {
+		return ErrFunnyNameTooShort
+	}
+	if len(name) > MaxFunnyNameLength {
+		return ErrFunnyNameTooLong
+	}
+	for _, c := range name {
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_') {
+			return fmt.Errorf("%w: %q contains invalid characters (only letters and underscores allowed)", ErrInvalidFunnyName, name)
+		}
+	}
+	return nil
+}
+
+// IsValidFunnyName reports whether the given name is a valid funny name from the curated list.
+// Validation checks format (letters and underscores only, 3-20 chars) and list membership.
+// Comparison is case-insensitive.
+func IsValidFunnyName(name string) bool {
+	if err := ValidateFunnyNameFormat(name); err != nil {
+		return false
+	}
+	upper := strings.ToUpper(name)
+	for _, valid := range funnyNameList {
+		if strings.ToUpper(valid) == upper {
+			return true
+		}
+	}
+	return false
+}
+
+// IsFunnyNameAvailable reports whether a funny name is both valid and not currently assigned.
+func IsFunnyNameAvailable(name string) bool {
+	if !IsValidFunnyName(name) {
+		return false
+	}
+	return !DefaultFunnyNameGenerator().IsUsed(name)
+}
+
+var funnyNameList = []string{
+	"ABBY",
+	"ARCHIE",
+	"ASTRO",
+	"AZrael",
+	"Barnacle",
+	"Biscuit",
+	"Boomer",
+	"Bubbles",
+	"Bugs",
+	"Buster",
+	"Buzz",
+	"Caillou",
+	"Cartoon",
+	"Casper",
+	"Chester",
+	"Chewie",
+	"Clifford",
+	"Coco",
+	"Courage",
+	"Cow",
+	"Daffy",
+	"Daisy",
+	"Dexter",
+	"Dino",
+	"Dobbie",
+	"Donald",
+	"Dottie",
+	"Douglas",
+	"Drake",
+	"Duke",
+	"Dylan",
+	"Eeyore",
+	"Elmo",
+	"Felix",
+	"Figaro",
+	"Fiona",
+	"Fireball",
+	"Flounder",
+	"Foot",
+	"Frankie",
+	"Garfield",
+	"George",
+	"Giggles",
+	"Goofy",
+	"Grandpa",
+	"Griffin",
+	"Hamlet",
+	"Hank",
+	"Hercules",
+	"Hobbes",
+	"Hoo",
+	"Hunter",
+	"Igor",
+	"Ivy",
+	"Jack",
+	"Jafar",
+	"Jasmine",
+	"Jellybean",
+	"Jerry",
+	"Kaa",
+	"Kermit",
+	"Kiki",
+	"Larry",
+	"Lassie",
+	"Leo",
+	"Lilo",
+	"Lola",
+	"Lucky",
+	"Luna",
+	"Maddie",
+	"Marvin",
+	"Max",
+	"Maya",
+	"Mickey",
+	"Milo",
+	"Minnie",
+	"Moe",
+	"Morty",
+	"Muffin",
+	"Nala",
+	"Nemo",
+	"Nibbles",
+	"Odie",
+	"Olaf",
+	"Oliver",
+	"Ollie",
+	"Oscar",
+	"Panda",
+	"Peanut",
+	"Pebbles",
+	"Pete",
+	"Pickles",
+	"Porky",
+	"Quacker",
+	"Quentin",
+	"Rafiki",
+	"Ralph",
+	"Rex",
+	"Roadrunner",
+	"Rover",
+	"Ruby",
+	"Salem",
+	"Sam",
+	"Sandy",
+	"Scooby",
+	"Scout",
+	"Sebastian",
+	"Shrek",
+	"Simba",
+	"Skimbles",
+	"Smokey",
+	"Sniffles",
+	"Snoopy",
+	"Sofia",
+	"Sonic",
+	"Sparky",
+	"Spencer",
+	"Spirit",
+	"Spongebob",
+	"Spot",
+	"Stanley",
+	"Stuart",
+	"Styx",
+	"Sugar",
+	"Sunny",
+	"Taz",
+	"Thomas",
+	"Tiger",
+	"Tigger",
+	"Tito",
+	"Tommy",
+	"Tony",
+	"Tweety",
+	"Tom",
+	"Ty",
+	"Vanilla",
+	"Vinnie",
+	"Waffles",
+	"Widget",
+	"Wiley",
+	"Winston",
+	"Woody",
+	"Zazu",
+	"Ziggy",
+	"Zippy",
+	"Zorro",
+}

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -14,14 +14,28 @@ const (
 )
 
 type FunnyName struct {
-	name  string
-	used  bool
-	index int
+	name string
+}
+
+// NewFunnyName creates a validated funny-name value object.
+func NewFunnyName(name string) (FunnyName, error) {
+	if err := ValidateFunnyNameFormat(name); err != nil {
+		return FunnyName{}, err
+	}
+	if !isFunnyNameInList(name) {
+		return FunnyName{}, ErrInvalidFunnyName
+	}
+	return FunnyName{name: name}, nil
+}
+
+// Name returns the funny name value.
+func (f FunnyName) Name() string {
+	return f.name
 }
 
 // String returns the funny name as a string.
 func (f FunnyName) String() string {
-	return f.name
+	return f.Name()
 }
 
 // IsValid returns true if the FunnyName is valid (non-empty and passes funny-name validation).
@@ -29,9 +43,15 @@ func (f FunnyName) IsValid() bool {
 	return IsValidFunnyName(f.name)
 }
 
+type funnyNameEntry struct {
+	funnyName FunnyName
+	used      bool
+	index     int
+}
+
 type FunnyNameGenerator struct {
 	mu     sync.Mutex
-	names  []FunnyName
+	names  []funnyNameEntry
 	used   map[string]bool
 	source *rand.Rand
 }
@@ -42,9 +62,13 @@ var (
 )
 
 func newFunnyNameGenerator(seed int64) *FunnyNameGenerator {
-	names := make([]FunnyName, len(funnyNameList))
+	names := make([]funnyNameEntry, len(funnyNameList))
 	for i, name := range funnyNameList {
-		names[i] = FunnyName{name: strings.ToUpper(name), used: false, index: i}
+		funnyName, err := NewFunnyName(strings.ToUpper(name))
+		if err != nil {
+			panic(fmt.Sprintf("initialize funny name generator: %v", err))
+		}
+		names[i] = funnyNameEntry{funnyName: funnyName, index: i}
 	}
 	src := rand.NewSource(seed)
 	return &FunnyNameGenerator{
@@ -100,7 +124,7 @@ func (g *FunnyNameGenerator) MarkAsUsed(name string) error {
 	}
 	upper := strings.ToUpper(trimmed)
 	for i := range g.names {
-		if g.names[i].name == upper {
+		if g.names[i].funnyName.Name() == upper {
 			g.names[i].used = true
 			g.used[upper] = true
 			return nil
@@ -120,7 +144,7 @@ func (g *FunnyNameGenerator) MarkAsAvailable(name string) error {
 	}
 	upper := strings.ToUpper(trimmed)
 	for i := range g.names {
-		if g.names[i].name == upper {
+		if g.names[i].funnyName.Name() == upper {
 			g.names[i].used = false
 			delete(g.used, upper)
 			return nil
@@ -148,9 +172,10 @@ func (g *FunnyNameGenerator) GetRandomName() (string, error) {
 
 	idx := available[g.source.Intn(len(available))]
 	g.names[idx].used = true
-	g.used[strings.ToUpper(g.names[idx].name)] = true
+	name := g.names[idx].funnyName.Name()
+	g.used[strings.ToUpper(name)] = true
 
-	return g.names[idx].name, nil
+	return name, nil
 }
 
 // Reset marks all funny names as available and clears the used set.
@@ -190,6 +215,10 @@ func IsValidFunnyName(name string) bool {
 	if err := ValidateFunnyNameFormat(name); err != nil {
 		return false
 	}
+	return isFunnyNameInList(name)
+}
+
+func isFunnyNameInList(name string) bool {
 	upper := strings.ToUpper(name)
 	for _, valid := range funnyNameList {
 		if strings.ToUpper(valid) == upper {

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -112,7 +112,11 @@ func (g *FunnyNameGenerator) AvailableCount() int {
 func (g *FunnyNameGenerator) IsUsed(name string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.used[strings.ToUpper(name)]
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return false
+	}
+	return g.used[strings.ToUpper(trimmed)]
 }
 
 // MarkAsUsed marks the given funny name as used so it won't be returned by GetRandomName.

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -7,13 +7,18 @@ import (
 	"sync"
 )
 
+// ==========================================
+// Constants
+// ==========================================
+
 const (
 	MinFunnyNameLength = 3
 	MaxFunnyNameLength = 30
-	// FunnyNamePattern is the regex pattern for valid funny names.
-	// Format: ^[A-Za-z_]+$ — letters and underscores only, no digits.
-	FunnyNamePattern = `^[A-Za-z_]+$`
 )
+
+// ==========================================
+// Funny Name Value Object
+// ==========================================
 
 type FunnyName struct {
 	name string
@@ -30,6 +35,10 @@ func NewFunnyName(name string) (FunnyName, error) {
 	return FunnyName{name: name}, nil
 }
 
+// ==========================================
+// Getters (Read-Only Accessors)
+// ==========================================
+
 // Name returns the funny name value.
 func (f FunnyName) Name() string {
 	return f.name
@@ -45,6 +54,10 @@ func (f FunnyName) IsValid() bool {
 	return IsValidFunnyName(f.name)
 }
 
+// ==========================================
+// Generator Support Types
+// ==========================================
+
 type funnyNameEntry struct {
 	funnyName FunnyName
 	used      bool
@@ -58,10 +71,18 @@ type FunnyNameGenerator struct {
 	source *rand.Rand
 }
 
+// ==========================================
+// Generator State
+// ==========================================
+
 var (
 	defaultGenerator *FunnyNameGenerator
 	once             sync.Once
 )
+
+// ==========================================
+// Generator Construction
+// ==========================================
 
 func newFunnyNameGenerator(seed int64) *FunnyNameGenerator {
 	names := make([]funnyNameEntry, len(funnyNameList))
@@ -94,6 +115,10 @@ func DefaultFunnyNameGenerator() *FunnyNameGenerator {
 func NewFunnyNameGenerator(seed int64) *FunnyNameGenerator {
 	return newFunnyNameGenerator(seed)
 }
+
+// ==========================================
+// Generator Operations
+// ==========================================
 
 // AvailableCount returns the number of funny names that are still available (not yet assigned).
 func (g *FunnyNameGenerator) AvailableCount() int {
@@ -194,6 +219,10 @@ func (g *FunnyNameGenerator) Reset() {
 	g.used = make(map[string]bool)
 }
 
+// ==========================================
+// Validation Helpers
+// ==========================================
+
 // ValidateFunnyNameFormat validates that a name conforms to the funny name format.
 // Valid names must be 3-30 characters, contain only letters and underscores, and not be empty.
 func ValidateFunnyNameFormat(name string) error {
@@ -241,6 +270,10 @@ func IsFunnyNameAvailable(name string) bool {
 	}
 	return !DefaultFunnyNameGenerator().IsUsed(name)
 }
+
+// ==========================================
+// Curated Funny Name List
+// ==========================================
 
 var funnyNameList = []string{
 	"ABBY",

--- a/internal/core/domain/funny_names.go
+++ b/internal/core/domain/funny_names.go
@@ -191,7 +191,7 @@ func (g *FunnyNameGenerator) Reset() {
 }
 
 // ValidateFunnyNameFormat validates that a name conforms to the funny name format.
-// Valid names must be 3-20 characters, contain only letters and underscores, and not be empty.
+// Valid names must be 3-30 characters, contain only letters and underscores, and not be empty.
 func ValidateFunnyNameFormat(name string) error {
 	if name == "" {
 		return ErrInvalidFunnyName
@@ -211,7 +211,7 @@ func ValidateFunnyNameFormat(name string) error {
 }
 
 // IsValidFunnyName reports whether the given name is a valid funny name from the curated list.
-// Validation checks format (letters and underscores only, 3-20 chars) and list membership.
+// Validation checks format (letters and underscores only, 3-30 chars) and list membership.
 // Comparison is case-insensitive.
 func IsValidFunnyName(name string) bool {
 	if err := ValidateFunnyNameFormat(name); err != nil {

--- a/internal/core/domain/funny_names_test.go
+++ b/internal/core/domain/funny_names_test.go
@@ -1,0 +1,339 @@
+package domain
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestValidateFunnyNameFormat_ValidNames(t *testing.T) {
+	validNames := []string{"Mickey", "Donald", "BARNACLE", "Pickles", "Scooby", "Jerry", "Tom", "Bugs", "Daffy"}
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateFunnyNameFormat(name); err != nil {
+				t.Errorf("ValidateFunnyNameFormat(%q) returned error: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestValidateFunnyNameFormat_InvalidNames(t *testing.T) {
+	invalidCases := []struct {
+		name    string
+		errType error
+	}{
+		{"", ErrInvalidFunnyName},
+		{"Mickey123", ErrInvalidFunnyName},
+		{"123Bugs", ErrInvalidFunnyName},
+		{"Mickey-1", ErrInvalidFunnyName},
+		{"Tom & Jerry", ErrInvalidFunnyName},
+		{"Scooby!", ErrInvalidFunnyName},
+		{"Daffy?", ErrInvalidFunnyName},
+		{"Mickey ", ErrInvalidFunnyName},
+		{" Mickey", ErrInvalidFunnyName},
+		{"a", ErrFunnyNameTooShort},
+		{"ab", ErrFunnyNameTooShort},
+		{"THISNAMEISWAYTOOLONGTOBEVALID", ErrFunnyNameTooLong},
+	}
+
+	for _, tc := range invalidCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFunnyNameFormat(tc.name)
+			if err == nil {
+				t.Errorf("ValidateFunnyNameFormat(%q) = nil, expected error", tc.name)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.errType.Error()) {
+				t.Errorf("ValidateFunnyNameFormat(%q) = %v, expected containing %v", tc.name, err, tc.errType)
+			}
+		})
+	}
+}
+
+func TestValidateFunnyNameFormat_UnderscoresAllowed(t *testing.T) {
+	validUnderscoreNames := []string{"Mickey_Mouse", "Tom_Jerry", "Scooby_Doo", "Road_Runner"}
+	for _, name := range validUnderscoreNames {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateFunnyNameFormat(name); err != nil {
+				t.Errorf("ValidateFunnyNameFormat(%q) returned error: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestIsValidFunnyName_FromList(t *testing.T) {
+	knownNames := []string{"Mickey", "Donald", "BARNACLE", "Pickles", "Scooby", "Jerry", "Tom", "Bugs", "Daffy", "Goofy"}
+	for _, name := range knownNames {
+		t.Run(name, func(t *testing.T) {
+			if !IsValidFunnyName(name) {
+				t.Errorf("IsValidFunnyName(%q) = false, expected true", name)
+			}
+		})
+	}
+}
+
+func TestIsValidFunnyName_NotInList(t *testing.T) {
+	notInList := []string{"Basuruk", "OmniView", "OmniInspect", "Random", "Xyz", "ABCDEFGHIJKLMNOP", "TestName", " Mickey", "Mickey "}
+	for _, name := range notInList {
+		t.Run(name, func(t *testing.T) {
+			if IsValidFunnyName(name) {
+				t.Errorf("IsValidFunnyName(%q) = true, expected false (not in curated list)", name)
+			}
+		})
+	}
+}
+
+func TestIsValidFunnyName_CaseInsensitive(t *testing.T) {
+	variations := []struct {
+		name  string
+		valid bool
+	}{
+		{"mickey", true},
+		{"MICKEY", true},
+		{"MiCkEy", true},
+		{"mickey", true},
+		{"BARNACLE", true},
+		{"barnacle", true},
+		{"Barnacle", true},
+	}
+
+	for _, v := range variations {
+		t.Run(v.name, func(t *testing.T) {
+			result := IsValidFunnyName(v.name)
+			if result != v.valid {
+				t.Errorf("IsValidFunnyName(%q) = %v, expected %v", v.name, result, v.valid)
+			}
+		})
+	}
+}
+
+func TestFunnyNameGenerator_GetRandomName(t *testing.T) {
+	gen := NewFunnyNameGenerator(42)
+
+	name1, err := gen.GetRandomName()
+	if err != nil {
+		t.Fatalf("GetRandomName() returned error: %v", err)
+	}
+	if name1 == "" {
+		t.Error("GetRandomName() returned empty string")
+	}
+	if !IsValidFunnyName(name1) {
+		t.Errorf("GetRandomName() returned invalid funny name: %q", name1)
+	}
+	if name1 != strings.ToUpper(name1) {
+		t.Errorf("GetRandomName() returned %q, expected uppercase procedure-safe name", name1)
+	}
+}
+
+func TestFunnyNameGenerator_NoDuplicates(t *testing.T) {
+	gen := NewFunnyNameGenerator(42)
+	seen := make(map[string]bool)
+
+	initialCount := gen.AvailableCount()
+	if initialCount == 0 {
+		t.Fatal("Generator has no available names")
+	}
+
+	for i := 0; i < initialCount; i++ {
+		name, err := gen.GetRandomName()
+		if err != nil {
+			t.Fatalf("GetRandomName() iteration %d returned error: %v", i, err)
+		}
+		if seen[name] {
+			t.Errorf("GetRandomName() returned duplicate name %q", name)
+		}
+		seen[name] = true
+	}
+
+	finalCount := gen.AvailableCount()
+	if finalCount != 0 {
+		t.Errorf("After exhausting all names, AvailableCount() = %d, expected 0", finalCount)
+	}
+
+	_, err := gen.GetRandomName()
+	if err != ErrNoAvailableNames {
+		t.Errorf("GetRandomName() after exhaustion = %v, expected ErrNoAvailableNames", err)
+	}
+}
+
+func TestFunnyNameGenerator_MarkAsUsed(t *testing.T) {
+	gen := NewFunnyNameGenerator(99)
+
+	name, _ := gen.GetRandomName()
+	if !gen.IsUsed(name) {
+		t.Errorf("After GetRandomName() returned %q, IsUsed(%q) = false, expected true", name, name)
+	}
+
+	gen.MarkAsAvailable(name)
+	if gen.IsUsed(name) {
+		t.Errorf("After MarkAsAvailable(%q), IsUsed(%q) = true, expected false", name, name)
+	}
+}
+
+func TestFunnyNameGenerator_MarkAsAvailable(t *testing.T) {
+	gen := NewFunnyNameGenerator(99)
+
+	initialCount := gen.AvailableCount()
+	name, _ := gen.GetRandomName()
+
+	afterCount := gen.AvailableCount()
+	if afterCount != initialCount-1 {
+		t.Errorf("After GetRandomName(), AvailableCount() = %d, expected %d", afterCount, initialCount-1)
+	}
+
+	gen.MarkAsAvailable(name)
+	restoredCount := gen.AvailableCount()
+	if restoredCount != initialCount {
+		t.Errorf("After MarkAsAvailable(), AvailableCount() = %d, expected %d", restoredCount, initialCount)
+	}
+
+	_, err := gen.GetRandomName()
+	if err != nil {
+		t.Errorf("GetRandomName() after MarkAsAvailable() returned error: %v", err)
+	}
+}
+
+func TestFunnyNameGenerator_Reset(t *testing.T) {
+	gen := NewFunnyNameGenerator(99)
+
+	initialCount := gen.AvailableCount()
+	gen.GetRandomName()
+	gen.GetRandomName()
+	gen.GetRandomName()
+
+	if gen.AvailableCount() != initialCount-3 {
+		t.Errorf("After 3 GetRandomName() calls, AvailableCount() = %d, expected %d", gen.AvailableCount(), initialCount-3)
+	}
+
+	gen.Reset()
+	if gen.AvailableCount() != initialCount {
+		t.Errorf("After Reset(), AvailableCount() = %d, expected %d", gen.AvailableCount(), initialCount)
+	}
+}
+
+func TestFunnyNameGenerator_ThreadSafety(t *testing.T) {
+	gen := NewFunnyNameGenerator(42)
+	var wg sync.WaitGroup
+	results := make(chan string, 100)
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			name, _ := gen.GetRandomName()
+			results <- name
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	seen := make(map[string]bool)
+	for name := range results {
+		if seen[name] {
+			t.Errorf("Thread safety violation: duplicate name %q returned", name)
+		}
+		seen[name] = true
+	}
+}
+
+func TestFunnyNameGenerator_DeterministicWithSameSeed(t *testing.T) {
+	gen1 := NewFunnyNameGenerator(12345)
+	gen2 := NewFunnyNameGenerator(12345)
+
+	for i := 0; i < 10; i++ {
+		name1, _ := gen1.GetRandomName()
+		name2, _ := gen2.GetRandomName()
+		if name1 != name2 {
+			t.Errorf("Generators with same seed produced different names at iteration %d: %q vs %q", i, name1, name2)
+		}
+	}
+}
+
+func TestFunnyName_Interface(t *testing.T) {
+	fn := FunnyName{name: "Mickey", used: false, index: 0}
+
+	if fn.String() != "Mickey" {
+		t.Errorf("String() = %q, expected %q", fn.String(), "Mickey")
+	}
+
+	if !fn.IsValid() {
+		t.Error("IsValid() = false, expected true for non-empty name with length >= 3")
+	}
+
+	emptyFn := FunnyName{name: ""}
+	if emptyFn.IsValid() {
+		t.Error("IsValid() = true for empty FunnyName, expected false")
+	}
+
+	shortFn := FunnyName{name: "AB"}
+	if shortFn.IsValid() {
+		t.Error("IsValid() = true for 2-char FunnyName, expected false")
+	}
+
+	invalidFn := FunnyName{name: "Mickey123"}
+	if invalidFn.IsValid() {
+		t.Error("IsValid() = true for FunnyName with digits, expected false")
+	}
+}
+
+func TestFunnyNameGenerator_CollisionHandling(t *testing.T) {
+	gen := NewFunnyNameGenerator(42)
+
+	assigned := make(map[string]bool)
+	for i := 0; i < gen.AvailableCount(); i++ {
+		name, err := gen.GetRandomName()
+		if err != nil {
+			t.Fatalf("GetRandomName() iteration %d returned error: %v", i, err)
+		}
+		if assigned[name] {
+			t.Errorf("Collision detected: name %q assigned twice", name)
+		}
+		assigned[name] = true
+	}
+}
+
+func TestFunnyNameGenerator_AvailabilityTracking(t *testing.T) {
+	gen := NewFunnyNameGenerator(77)
+
+	invalidName := "NotAValidFunnyName"
+	if IsFunnyNameAvailable(invalidName) {
+		t.Errorf("IsFunnyNameAvailable(%q) = true for invalid name", invalidName)
+	}
+
+	firstName, err := gen.GetRandomName()
+	if err != nil {
+		t.Fatalf("GetRandomName() returned error: %v", err)
+	}
+
+	if !gen.IsUsed(firstName) {
+		t.Errorf("After GetRandomName(), IsUsed(%q) = false, expected true", firstName)
+	}
+
+	gen.MarkAsAvailable(firstName)
+	if gen.IsUsed(firstName) {
+		t.Errorf("After MarkAsAvailable(%q), IsUsed(%q) = true, expected false", firstName, firstName)
+	}
+}
+
+func BenchmarkValidateFunnyNameFormat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ValidateFunnyNameFormat("Mickey")
+	}
+}
+
+func BenchmarkIsValidFunnyName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		IsValidFunnyName("Mickey")
+	}
+}
+
+func BenchmarkFunnyNameGenerator_GetRandomName(b *testing.B) {
+	gen := NewFunnyNameGenerator(42)
+	for i := 0; i < b.N; i++ {
+		if i%100 == 0 {
+			gen.Reset()
+		}
+		gen.GetRandomName()
+	}
+}

--- a/internal/core/domain/funny_names_test.go
+++ b/internal/core/domain/funny_names_test.go
@@ -156,7 +156,7 @@ func TestFunnyNameGenerator_NoDuplicates(t *testing.T) {
 	}
 }
 
-func TestFunnyNameGenerator_MarkAsUsed(t *testing.T) {
+func TestFunnyNameGenerator_GetRandomNameMarksUsed(t *testing.T) {
 	gen := NewFunnyNameGenerator(99)
 
 	name, err := gen.GetRandomName()
@@ -172,6 +172,33 @@ func TestFunnyNameGenerator_MarkAsUsed(t *testing.T) {
 	}
 	if gen.IsUsed(name) {
 		t.Errorf("After MarkAsAvailable(%q), IsUsed(%q) = true, expected false", name, name)
+	}
+}
+
+func TestFunnyNameGenerator_MarkAsUsed(t *testing.T) {
+	gen := NewFunnyNameGenerator(99)
+
+	knownValidName, err := gen.GetRandomName()
+	if err != nil {
+		t.Fatalf("GetRandomName() returned error: %v", err)
+	}
+	if err := gen.MarkAsAvailable(knownValidName); err != nil {
+		t.Fatalf("MarkAsAvailable(%q) returned error: %v", knownValidName, err)
+	}
+
+	if err := gen.MarkAsUsed(knownValidName); err != nil {
+		t.Fatalf("MarkAsUsed(%q) returned error: %v", knownValidName, err)
+	}
+	if !gen.IsUsed(knownValidName) {
+		t.Errorf("After MarkAsUsed(%q), IsUsed(%q) = false, expected true", knownValidName, knownValidName)
+	}
+
+	testCases := []string{"", "   ", "NOTANAME"}
+	for _, name := range testCases {
+		err := gen.MarkAsUsed(name)
+		if !errors.Is(err, ErrInvalidFunnyName) {
+			t.Errorf("MarkAsUsed(%q) error = %v, expected ErrInvalidFunnyName", name, err)
+		}
 	}
 }
 

--- a/internal/core/domain/funny_names_test.go
+++ b/internal/core/domain/funny_names_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -43,8 +44,8 @@ func TestValidateFunnyNameFormat_InvalidNames(t *testing.T) {
 				t.Errorf("ValidateFunnyNameFormat(%q) = nil, expected error", tc.name)
 				return
 			}
-			if !strings.Contains(err.Error(), tc.errType.Error()) {
-				t.Errorf("ValidateFunnyNameFormat(%q) = %v, expected containing %v", tc.name, err, tc.errType)
+			if !errors.Is(err, tc.errType) {
+				t.Errorf("ValidateFunnyNameFormat(%q) = %v, expected %v", tc.name, err, tc.errType)
 			}
 		})
 	}
@@ -151,7 +152,7 @@ func TestFunnyNameGenerator_NoDuplicates(t *testing.T) {
 	}
 
 	_, err := gen.GetRandomName()
-	if err != ErrNoAvailableNames {
+	if !errors.Is(err, ErrNoAvailableNames) {
 		t.Errorf("GetRandomName() after exhaustion = %v, expected ErrNoAvailableNames", err)
 	}
 }
@@ -281,7 +282,8 @@ func TestFunnyNameGenerator_CollisionHandling(t *testing.T) {
 	gen := NewFunnyNameGenerator(42)
 
 	assigned := make(map[string]bool)
-	for i := 0; i < gen.AvailableCount(); i++ {
+	initialCount := gen.AvailableCount()
+	for i := 0; i < initialCount; i++ {
 		name, err := gen.GetRandomName()
 		if err != nil {
 			t.Fatalf("GetRandomName() iteration %d returned error: %v", i, err)

--- a/internal/core/domain/funny_names_test.go
+++ b/internal/core/domain/funny_names_test.go
@@ -167,7 +167,9 @@ func TestFunnyNameGenerator_MarkAsUsed(t *testing.T) {
 		t.Errorf("After GetRandomName() returned %q, IsUsed(%q) = false, expected true", name, name)
 	}
 
-	gen.MarkAsAvailable(name)
+	if err := gen.MarkAsAvailable(name); err != nil {
+		t.Fatalf("MarkAsAvailable(%q) returned error: %v", name, err)
+	}
 	if gen.IsUsed(name) {
 		t.Errorf("After MarkAsAvailable(%q), IsUsed(%q) = true, expected false", name, name)
 	}
@@ -187,7 +189,9 @@ func TestFunnyNameGenerator_MarkAsAvailable(t *testing.T) {
 		t.Errorf("After GetRandomName(), AvailableCount() = %d, expected %d", afterCount, initialCount-1)
 	}
 
-	gen.MarkAsAvailable(name)
+	if err := gen.MarkAsAvailable(name); err != nil {
+		t.Fatalf("MarkAsAvailable(%q) returned error: %v", name, err)
+	}
 	restoredCount := gen.AvailableCount()
 	if restoredCount != initialCount {
 		t.Errorf("After MarkAsAvailable(), AvailableCount() = %d, expected %d", restoredCount, initialCount)
@@ -344,7 +348,9 @@ func TestFunnyNameGenerator_AvailabilityTracking(t *testing.T) {
 		t.Errorf("After GetRandomName(), IsUsed(%q) = false, expected true", firstName)
 	}
 
-	gen.MarkAsAvailable(firstName)
+	if err := gen.MarkAsAvailable(firstName); err != nil {
+		t.Fatalf("MarkAsAvailable(%q) returned error: %v", firstName, err)
+	}
 	if gen.IsUsed(firstName) {
 		t.Errorf("After MarkAsAvailable(%q), IsUsed(%q) = true, expected false", firstName, firstName)
 	}

--- a/internal/core/domain/funny_names_test.go
+++ b/internal/core/domain/funny_names_test.go
@@ -92,7 +92,6 @@ func TestIsValidFunnyName_CaseInsensitive(t *testing.T) {
 		{"mickey", true},
 		{"MICKEY", true},
 		{"MiCkEy", true},
-		{"mickey", true},
 		{"BARNACLE", true},
 		{"barnacle", true},
 		{"Barnacle", true},
@@ -160,7 +159,10 @@ func TestFunnyNameGenerator_NoDuplicates(t *testing.T) {
 func TestFunnyNameGenerator_MarkAsUsed(t *testing.T) {
 	gen := NewFunnyNameGenerator(99)
 
-	name, _ := gen.GetRandomName()
+	name, err := gen.GetRandomName()
+	if err != nil {
+		t.Fatalf("GetRandomName() returned error: %v", err)
+	}
 	if !gen.IsUsed(name) {
 		t.Errorf("After GetRandomName() returned %q, IsUsed(%q) = false, expected true", name, name)
 	}
@@ -175,7 +177,10 @@ func TestFunnyNameGenerator_MarkAsAvailable(t *testing.T) {
 	gen := NewFunnyNameGenerator(99)
 
 	initialCount := gen.AvailableCount()
-	name, _ := gen.GetRandomName()
+	name, err := gen.GetRandomName()
+	if err != nil {
+		t.Fatalf("GetRandomName() returned error: %v", err)
+	}
 
 	afterCount := gen.AvailableCount()
 	if afterCount != initialCount-1 {
@@ -188,7 +193,7 @@ func TestFunnyNameGenerator_MarkAsAvailable(t *testing.T) {
 		t.Errorf("After MarkAsAvailable(), AvailableCount() = %d, expected %d", restoredCount, initialCount)
 	}
 
-	_, err := gen.GetRandomName()
+	_, err = gen.GetRandomName()
 	if err != nil {
 		t.Errorf("GetRandomName() after MarkAsAvailable() returned error: %v", err)
 	}
@@ -198,9 +203,11 @@ func TestFunnyNameGenerator_Reset(t *testing.T) {
 	gen := NewFunnyNameGenerator(99)
 
 	initialCount := gen.AvailableCount()
-	gen.GetRandomName()
-	gen.GetRandomName()
-	gen.GetRandomName()
+	for i := 0; i < 3; i++ {
+		if _, err := gen.GetRandomName(); err != nil {
+			t.Fatalf("GetRandomName() iteration %d returned error: %v", i, err)
+		}
+	}
 
 	if gen.AvailableCount() != initialCount-3 {
 		t.Errorf("After 3 GetRandomName() calls, AvailableCount() = %d, expected %d", gen.AvailableCount(), initialCount-3)
@@ -216,18 +223,28 @@ func TestFunnyNameGenerator_ThreadSafety(t *testing.T) {
 	gen := NewFunnyNameGenerator(42)
 	var wg sync.WaitGroup
 	results := make(chan string, 100)
+	errCh := make(chan error, 50)
 
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			name, _ := gen.GetRandomName()
+			name, err := gen.GetRandomName()
+			if err != nil {
+				errCh <- err
+				return
+			}
 			results <- name
 		}()
 	}
 
 	wg.Wait()
 	close(results)
+	close(errCh)
+
+	if err, ok := <-errCh; ok {
+		t.Fatalf("GetRandomName() in concurrent worker returned error: %v", err)
+	}
 
 	seen := make(map[string]bool)
 	for name := range results {
@@ -243,8 +260,14 @@ func TestFunnyNameGenerator_DeterministicWithSameSeed(t *testing.T) {
 	gen2 := NewFunnyNameGenerator(12345)
 
 	for i := 0; i < 10; i++ {
-		name1, _ := gen1.GetRandomName()
-		name2, _ := gen2.GetRandomName()
+		name1, err := gen1.GetRandomName()
+		if err != nil {
+			t.Fatalf("gen1.GetRandomName() iteration %d returned error: %v", i, err)
+		}
+		name2, err := gen2.GetRandomName()
+		if err != nil {
+			t.Fatalf("gen2.GetRandomName() iteration %d returned error: %v", i, err)
+		}
 		if name1 != name2 {
 			t.Errorf("Generators with same seed produced different names at iteration %d: %q vs %q", i, name1, name2)
 		}
@@ -252,7 +275,14 @@ func TestFunnyNameGenerator_DeterministicWithSameSeed(t *testing.T) {
 }
 
 func TestFunnyName_Interface(t *testing.T) {
-	fn := FunnyName{name: "Mickey", used: false, index: 0}
+	fn, err := NewFunnyName("Mickey")
+	if err != nil {
+		t.Fatalf("NewFunnyName() returned error: %v", err)
+	}
+
+	if fn.Name() != "Mickey" {
+		t.Errorf("Name() = %q, expected %q", fn.Name(), "Mickey")
+	}
 
 	if fn.String() != "Mickey" {
 		t.Errorf("String() = %q, expected %q", fn.String(), "Mickey")
@@ -262,19 +292,21 @@ func TestFunnyName_Interface(t *testing.T) {
 		t.Error("IsValid() = false, expected true for non-empty name with length >= 3")
 	}
 
-	emptyFn := FunnyName{name: ""}
-	if emptyFn.IsValid() {
-		t.Error("IsValid() = true for empty FunnyName, expected false")
+	var zeroFn FunnyName
+	if zeroFn.IsValid() {
+		t.Error("IsValid() = true for zero-value FunnyName, expected false")
 	}
 
-	shortFn := FunnyName{name: "AB"}
-	if shortFn.IsValid() {
-		t.Error("IsValid() = true for 2-char FunnyName, expected false")
+	if _, err := NewFunnyName(""); !errors.Is(err, ErrInvalidFunnyName) {
+		t.Errorf("NewFunnyName(\"\") error = %v, expected ErrInvalidFunnyName", err)
 	}
 
-	invalidFn := FunnyName{name: "Mickey123"}
-	if invalidFn.IsValid() {
-		t.Error("IsValid() = true for FunnyName with digits, expected false")
+	if _, err := NewFunnyName("AB"); !errors.Is(err, ErrFunnyNameTooShort) {
+		t.Errorf("NewFunnyName(\"AB\") error = %v, expected ErrFunnyNameTooShort", err)
+	}
+
+	if _, err := NewFunnyName("Mickey123"); !errors.Is(err, ErrInvalidFunnyName) {
+		t.Errorf("NewFunnyName(\"Mickey123\") error = %v, expected ErrInvalidFunnyName", err)
 	}
 }
 
@@ -336,6 +368,8 @@ func BenchmarkFunnyNameGenerator_GetRandomName(b *testing.B) {
 		if i%100 == 0 {
 			gen.Reset()
 		}
-		gen.GetRandomName()
+		if _, err := gen.GetRandomName(); err != nil {
+			b.Fatalf("GetRandomName() iteration %d returned error: %v", i, err)
+		}
 	}
 }

--- a/internal/core/domain/funny_names_test.go
+++ b/internal/core/domain/funny_names_test.go
@@ -34,7 +34,7 @@ func TestValidateFunnyNameFormat_InvalidNames(t *testing.T) {
 		{" Mickey", ErrInvalidFunnyName},
 		{"a", ErrFunnyNameTooShort},
 		{"ab", ErrFunnyNameTooShort},
-		{"THISNAMEISWAYTOOLONGTOBEVALID", ErrFunnyNameTooLong},
+		{"THISNAMEISWAYTOOLONGTOBEVALIDXYZ", ErrFunnyNameTooLong},
 	}
 
 	for _, tc := range invalidCases {

--- a/workflow.md
+++ b/workflow.md
@@ -1,0 +1,92 @@
+# Workflow: Multi-Subscriber Message Isolation - Brainstorming to Architecture
+
+## Context
+
+**Source**: Brainstorming session (`_bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md`)
+
+**Problem**: OmniView/OmniInspect trace messages broadcast to ALL subscribers instead of being delivered to the intended subscriber. IFS Cloud executes trace calls under IFS app user identity, NOT the debugging OmniView user - making it impossible to correlate caller and subscriber.
+
+**Selected Solution**: Dynamic procedure per subscriber - `TRACE_MESSAGE_<name>('msg')` embeds subscriber identity at compile-time. No runtime coordination, no extra parameters.
+
+---
+
+## Pre-Architecture Checklist
+
+- [x] Brainstorming session complete
+- [x] Solution approach selected: Dynamic procedure per subscriber
+- [x] Edge cases resolved (see below)
+- [ ] Architecture design created via `bmad-create-architecture`
+- [ ] Stories created via `bmad-create-epics-and-stories`
+
+---
+
+## Resolved Decisions (from Brainstorming)
+
+### Name & Format
+- **Name format**: `< 30 chars, `^[A-Za-z_]+$` (letters and underscores only, no numbers)
+- **Name uniqueness**: Use subscriber's existing unique ID (e.g., `SUB_0CC283A4...`)
+- **Idempotent creation**: Check if exists, only create if missing
+
+### SQL Injection Prevention
+- Strict format validation: `^[A-Za-z_]+$`
+- Subscriber name comes from internal ID, not user input
+
+### Package Invalidation
+- Accepted risk
+- App has recovery mechanism (redeploys on restart if package invalidated)
+
+### Danger Zone Options
+1. Delete subscriber-specific method only (per-subscriber cleanup)
+2. Drop entire `OMNI_TRACER_API` package (deletes ALL generated methods)
+
+### Auto-Redeploy
+- Already implemented - if `OMNI_TRACER_API` package missing on startup, OmniView redeploys
+
+### Permissions
+- Any database user can call generated procedures
+
+### Scalability
+- N subscribers supported, no hard limit
+
+---
+
+## Key Insight
+
+> "Dynamic procedure wins: Moves subscriber identity to **compile-time** — the human picks a memorable name, embeds it in IFS code. No runtime coordination needed. The method name IS the routing key."
+
+Developer ergonomics: `TRACE_MESSAGE_barnacle('test')` has same friction as `Trace_Message('test')` — one argument, no extra parameter.
+
+---
+
+## How Dynamic Procedure Works
+
+```
+1. Client registers → OmniView generates & deploys TRACE_MESSAGE_SUB_XXX()
+2. IFS developer calls OMNI_TRACER_API.TRACE_MESSAGE_SUB_XXX('debug msg')
+3. Procedure internally enqueues with recipient_list = 'SUB_XXX'
+4. Only SUB_XXX's OmniView instance dequeues that message
+```
+
+---
+
+## Input Documents for Architecture
+
+| Document | Purpose |
+|----------|---------|
+| `docs/SUBSCRIBER_ISOLATION_SOLUTION.md` | Original solution options (IP filtering, explicit param, CLIENT_IDENTIFIER, session binding, hybrid) |
+| `docs/ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md` | Current architecture, obsolete components, multi-subscriber implementation plan |
+| `_bmad-output/brainstorming/brainstorming-session-2026-04-19-2221.md` | This session's decisions |
+
+---
+
+## Next Steps
+
+1. **Run `bmad-create-architecture`** to design the implementation for:
+   - PL/SQL changes to `OMNI_TRACER_API` package (generate/drop procedures)
+   - Go-side changes to call new procedure naming convention
+   - Subscriber registration flow changes
+   - Danger zone UI implementation
+
+2. **Run `bmad-create-epics-and-stories`** after architecture is complete
+
+3. **Implement stories** via `bmad-dev-story`


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request implements **Epic 1, Story 1: Funny Name Value Object** for the OmniInspect multi-subscriber message isolation system.

### What Was Implemented

**Core Feature:** A `FunnyName` value object that auto-assigns memorable cartoon character names (e.g., BARNACLE, PICKLES, NIBBLES) to subscribers for generating unique procedure names like `TRACE_MESSAGE_BARNACLE('msg')`.

### Key Components Added

| File | Purpose |
|------|---------|
| `internal/core/domain/funny_names.go` | FunnyNameGenerator, validation functions, and curated list of 120+ cartoon character names |
| `internal/core/domain/funny_names_test.go` | 16 comprehensive unit tests covering validation, generation, and thread safety |
| `internal/core/domain/errors.go` | New sentinel errors for funny name validation |
| `_bmad-output/...` | Planning and tracking artifacts (sprint status, architecture, epics, brainstorming) |

### Functionality Delivered

- **Funny name assignment:** System auto-assigns names from curated list (Mickey, Donald, Bugs, Scooby, etc.)
- **Collision handling:** Generator tracks used names and picks another available name automatically
- **Thread-safe access:** Uses `sync.Mutex` for safe concurrent access
- **SQL injection prevention:** Strict format validation (`^[A-Za-z_]+) - only letters and underscores
- **Case normalization:** All names normalized to uppercase for procedure-safe names

### Verification

- All 16 unit tests passing
- `make test` and `make lint` passing
- Senior developer review approved

---

<think>Let me analyze the code changes to understand what was implemented:

1. In `internal/core/domain/funny_names.go`:
   - Removed the `index` field from `funnyNameEntry` struct
   - Changed the initialization logic to use a slice with `append` instead of direct indexing
   - Added deduplication check using a `seen` map to detect duplicates in the curated list
   - Added panic for duplicate names in the curated list
   - Added documentation comments

2. In `internal/core/domain/funny_names_test.go`:
   - Renamed test `TestFunnyNameGenerator_MarkAsUsed` to `TestFunnyNameGenerator_GetRandomNameMarksUsed`
   - Added a new `TestFunnyNameGenerator_MarkAsUsed` test that verifies the `MarkAsUsed` and `IsUsed` functionality

The changes seem to focus on:
1. Improving the initialization process of the FunnyNameGenerator
2. Adding validation for duplicate names in the curated list
3. Adding comprehensive tests for the `MarkAsUsed` functionality

This is related to multi-subscriber implementation, Epic 1 User Story 1.</think>

## Pull Request Summary

This pull request implements improvements to the `FunnyNameGenerator` in the domain layer with the following changes:

**Code Changes (`internal/core/domain/funny_names.go`):**
- Removed the `index` field from `funnyNameEntry` struct as it's no longer needed
- Refactored the generator initialization to use a map-based deduplication check, ensuring no duplicate names exist in the curated list at startup
- Added panic behavior to catch configuration errors where duplicate names are defined in the curated list
- Added documentation comment for the `isFunnyNameInList` function

**Test Changes (`internal/core/domain/funny_names_test.go`):**
- Renamed `TestFunnyNameGenerator_MarkAsUsed` to `TestFunnyNameGenerator_GetRandomNameMarksUsed` for clearer test intent
- Added new `TestFunnyNameGenerator_MarkAsUsed` test that validates:
  - The `MarkAsUsed` method correctly marks a name as used
  - The `IsUsed` method returns true after marking
  - Invalid names (empty, whitespace, non-existent) properly return `ErrInvalidFunnyName`

These changes improve the robustness of the FunnyNameGenerator by preventing silent duplicates in configuration and enhancing test coverage for the marking functionality used in subscriber name management.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added domain-level validation and a deterministic name-generation mechanism for subscriber routing
  * Enhanced project configuration with an `added_modes` setting for flexible mode composition

* **Documentation**
  * Expanded architecture/decision records, workflow guidance, sprint tracking, and planning artifacts
  * Added a brainstorming record capturing evaluated alternatives and chosen direction

* **Tests**
  * Comprehensive unit and concurrency tests plus benchmarks for validation and name-generation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->