### PR TITLE
feat: Move procedure call display next to database name in header and…

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-move-procedure-call-next-to-database-name.md
+++ b/_bmad-output/implementation-artifacts/spec-move-procedure-call-next-to-database-name.md
@@ -1,0 +1,35 @@
+---
+title: 'Move Procedure Call Next To Database Name'
+type: 'feature'
+created: '2026-05-12'
+status: 'done'
+route: 'one-shot'
+---
+
+# Move Procedure Call Next To Database Name
+
+## Intent
+
+**Problem:** The generated funny-name procedure call was visible in the main header, but it rendered as a separate header detail line instead of sitting next to the active database name.
+
+**Approach:** Keep the procedure call in the header, compose it inline with the subtitle/database identity line, and style it with the existing purple API-caller color token.
+
+## Suggested Review Order
+
+**Header Placement**
+
+- Entry point: inline detail beside the database subtitle instead of a third line.
+  [`chrome.go:62`](../../internal/adapter/ui/chrome.go#L62)
+
+**Purple Styling**
+
+- Reuses the existing purple API-caller token for procedure-call emphasis.
+  [`styles.go:154`](../../internal/adapter/ui/styles/styles.go#L154)
+
+**Regression Coverage**
+
+- Verifies database name and procedure call share a header line.
+  [`main_screen_test.go:20`](../../internal/adapter/ui/main_screen_test.go#L20)
+
+- Test helpers make the header-line assertion explicit and reusable.
+  [`main_screen_test.go:540`](../../internal/adapter/ui/main_screen_test.go#L540)

--- a/internal/adapter/ui/chrome.go
+++ b/internal/adapter/ui/chrome.go
@@ -58,14 +58,27 @@ func renderCenteredOverlay(base, overlay string, width, height int) string {
 	return strings.Join(baseLines, "\n")
 }
 
-// renderScreenHeader: renders a header with title, supporting detail lines on the left and meta info on the right.
+// renderScreenHeader: renders a header with title, supporting detail next to the subtitle, and meta info on the right.
 func renderScreenHeader(width int, title, subtitle, detail, meta string) string {
 	leftParts := []string{styles.HeaderTitleStyle.Render(title)}
+	subtitleLine := ""
 	if strings.TrimSpace(subtitle) != "" {
-		leftParts = append(leftParts, styles.HeaderSubtitleStyle.Render(subtitle))
+		subtitleLine = styles.HeaderSubtitleStyle.Render(subtitle)
 	}
 	if strings.TrimSpace(detail) != "" {
-		leftParts = append(leftParts, detail)
+		if subtitleLine != "" {
+			subtitleLine = lipgloss.JoinHorizontal(
+				lipgloss.Center,
+				subtitleLine,
+				styles.HeaderSubtitleStyle.Render("  •  "),
+				detail,
+			)
+		} else {
+			subtitleLine = detail
+		}
+	}
+	if strings.TrimSpace(subtitleLine) != "" {
+		leftParts = append(leftParts, subtitleLine)
 	}
 
 	left := lipgloss.JoinVertical(lipgloss.Left, leftParts...)

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -21,6 +21,7 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	t.Parallel()
 
 	m := newTestMainModel(t, 120, 36)
+	m.appConfig = mustNewTestDatabaseSettings(t, "QA_DB")
 	m.subscriber = mustNewTestSubscriberWithFunnyName(t, "SUB_TEST", "BARNACLE")
 
 	layout := m.computeMainLayout()
@@ -30,6 +31,9 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	}
 	if strings.Contains(layout.statusBar, "TRACE_MESSAGE_") {
 		t.Fatalf("status bar should not contain procedure call, got: %s", layout.statusBar)
+	}
+	if !headerLineContainsAll(layout.header, "QA_DB", "OMNI_TRACER_API.TRACE_MESSAGE_BARNACLE('msg')") {
+		t.Fatalf("header should place procedure call next to database name, got: %s", layout.header)
 	}
 }
 
@@ -531,6 +535,34 @@ func mustNewTestSubscriberWithFunnyName(t *testing.T, name, funnyName string) *d
 	}
 
 	return subscriber
+}
+
+func mustNewTestDatabaseSettings(t *testing.T, databaseID string) *domain.DatabaseSettings {
+	t.Helper()
+
+	db, err := domain.NewDatabaseSettings(databaseID, "APPDB", "localhost", domain.DefaultOraclePort, "app", "secret")
+	if err != nil {
+		t.Fatalf("failed to create database settings: %v", err)
+	}
+
+	return db
+}
+
+func headerLineContainsAll(header string, parts ...string) bool {
+	for _, line := range strings.Split(header, "\n") {
+		containsAll := true
+		for _, part := range parts {
+			if !strings.Contains(line, part) {
+				containsAll = false
+				break
+			}
+		}
+		if containsAll {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newTestQueueMessage(t *testing.T) *domain.QueueMessage {

--- a/internal/adapter/ui/styles/styles.go
+++ b/internal/adapter/ui/styles/styles.go
@@ -152,7 +152,7 @@ var (
 			Bold(true)
 
 	ProcedureCallStyle = lipgloss.NewStyle().
-				Foreground(PrimaryColor).
+				Foreground(ApiCallerColor).
 				Bold(true)
 )
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refines the UI presentation of header information by integrating the procedure call display directly alongside the database name.

**Key Modifications and Technical Context:**

*   **Inline Header Composition (`internal/adapter/ui/chrome.go`):**
    *   The `renderScreenHeader` function has been refactored to dynamically compose the `subtitle` (database name) and `detail` (procedure call) on a single line.
    *   It now uses `lipgloss.JoinHorizontal(lipgloss.Center, ...)` to ensure that if both `subtitle` and `detail` are present, they are joined horizontally with a `" • "` separator, and are vertically centered relative to each other.
    *   A notable enhancement is the robust handling of cases where the `subtitle` might be empty. If only `detail` (the procedure call) is provided, it will still correctly populate the `subtitleLine`, ensuring the procedure call is always displayed on the intended header line, even without an active database name.

*   **Styling Consistency (`internal/adapter/ui/styles/styles.go`):**
    *   The `ProcedureCallStyle` has been updated to use `ApiCallerColor` (purple) instead of `PrimaryColor`. This change aligns the visual styling of procedure calls with other API-caller related elements, enhancing UI consistency and making procedure calls more distinct.

*   **Enhanced Test Coverage (`internal/adapter/ui/main_screen_test.go`):**
    *   The `TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader` test now explicitly sets a database ID (`"QA_DB"`) using the new `mustNewTestDatabaseSettings` helper. This is crucial for creating the necessary test context where both a database name and a procedure call are present, allowing for a full validation of their inline composition.
    *   A new helper function, `headerLineContainsAll`, has been introduced. This helper iterates through each line of the rendered header to verify that all specified parts (e.g., "QA_DB" and the procedure call) are present *within the same line*. This provides a flexible yet precise assertion for the new inline header layout, ensuring the functional requirement is met regardless of other header content.

This change directly addresses the problem of the procedure call rendering on a separate line, providing a more compact and visually integrated header experience.
<!-- kody-pr-summary:end -->