### PR TITLE
feat: Implement danger zone UI for deleting subscriber procedures and related functionality

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -74,12 +74,12 @@ development_status:
 
   # Epic 3 Stories
   3-1-drop-subscriber-procedure:
-    status: "ready-for-dev"
+    status: "done"
     title: "Drop Subscriber Procedure (Danger Zone)"
     epic: "Epic 3: Danger Zone Implementation"
     owner: "dev-agent"
-    last_updated: "2026-04-28"
-    notes: "Add danger zone option to delete subscriber-specific procedure"
+    last_updated: "2026-05-12"
+    notes: "DangerZoneStyle, danger zone UI, D key handler, confirmation modal, async command wiring. make test and make build passing."
 
   3-2-drop-entire-package:
     status: "ready-for-dev"
@@ -102,11 +102,11 @@ development_status:
 # ==========================================
 metrics:
   total_stories: 9
-  completed: 5
+  completed: 6
   in_progress: 0
-  ready_for_dev: 4
+  ready_for_dev: 3
   blocked: 0
-  completion_percentage: 56
+  completion_percentage: 67
 
 # ==========================================
 # EPIC SUMMARY
@@ -129,9 +129,9 @@ epic_summary:
   epic-3:
     title: "Epic 3: Danger Zone Implementation"
     stories_total: 3
-    stories_completed: 0
+    stories_completed: 1
     stories_in_progress: 0
-    status: "pending"
+    status: "in-progress"
 
 # ==========================================
 # NEXT ACTIONS

--- a/_bmad-output/implementation-artifacts/stories/3-1-drop-subscriber-procedure.md
+++ b/_bmad-output/implementation-artifacts/stories/3-1-drop-subscriber-procedure.md
@@ -1,0 +1,270 @@
+---
+story_key: "3-1-drop-subscriber-procedure"
+epic_key: "epic-3"
+title: "Drop Subscriber Procedure (Danger Zone)"
+status: "ready-for-dev"
+priority: "high"
+created_date: "2026-05-12"
+last_updated: "2026-05-12"
+---
+
+# ==========================================
+# STORY DEFINITION
+# ==========================================
+
+## Story
+
+As a subscriber,
+I want to delete my specific procedure,
+So that I can clean up when I no longer need tracing.
+
+## Background
+
+Epic 1 implemented per-subscriber procedure generation using auto-assigned funny names (e.g., BARNACLE, PICKLES). Each subscriber gets a unique `TRACE_MESSAGE_<FUNNY_NAME>()` procedure inside the `OMNI_TRACER_API` package.
+
+Epic 3 Story 3-1 adds a danger zone option in the Settings UI to delete only the subscriber's own procedure (not affecting other subscribers or the base package).
+
+**Epic 1 status**: COMPLETE ✅ (Stories 1-1 through 1-5 all done, routing tested with 2 subscribers)
+
+**Epic 2 status**: COMPLETE ✅ (Story 2-1 done - procedure name displayed in header)
+
+**This story depends on**: Epic 1 completion — procedure generation is working and procedures can be deleted
+
+---
+
+## Acceptance Criteria
+
+**Given** the subscriber is on the Settings screen
+**When** they select "Delete My Procedure"
+**Then** a confirmation dialog appears warning this action
+**And** if confirmed, the `TRACE_MESSAGE_<FUNNY_NAME>()` procedure is removed from OMNI_TRACER_API package
+
+**Given** the procedure is deleted
+**When** OmniView restarts
+**Then** if the subscriber is still registered, the procedure is regenerated
+
+---
+
+## Tasks/Subtasks
+
+### Task 1: Study existing Settings UI and danger zone requirements
+
+**Files**: `internal/adapter/ui/database_settings.go`, `_bmad-output/planning-artifacts/architecture.md`
+
+- [x] Read `database_settings.go` to understand current Settings screen structure
+- [x] Read architecture.md Pattern 4: Settings UI Danger Zone
+- [x] Understand confirmation dialog pattern used in the app
+- [x] Identify where danger zone options should be added
+
+### Task 2: Add DropSubscriberProcedure method to ProcedureGenerator
+
+**Files**: `internal/service/subscribers/procedure_generator.go`
+
+**Implementation approach**:
+- `DropSubscriberProcedure(subscriberName string) error` — removes the subscriber's procedure block from the package
+- Uses the same section markers (`-- @SECTION: SUBSCRIBER_GENERATED_METHOD : <name>`) that are used during creation
+- Idempotent: if procedure doesn't exist, return success
+- Must use Oracle `EXECUTE IMMEDIATE` with proper DDL to remove the procedure
+
+**DDL to drop procedure**:
+```sql
+ALTER PACKAGE OMNI_TRACER_API COMPILE BODY;
+```
+Or use dbms_utility to invalidate and recompile.
+
+**Note**: In Oracle, you cannot directly "drop" a procedure from a package body — you must either:
+1. Recompile the entire package body without the procedure (redeploy full package spec/body)
+2. Use `ALTER PACKAGE ... DROP PROCEDURE` (Oracle 12c+)
+
+Since OmniView uses package redeployment, the approach is:
+- Fetch current package body source
+- Remove the subscriber's procedure block (section between markers)
+- Redeploy the updated package body
+
+- [x] `DropSubscriberProcedure` already exists in procedure_generator.go (implemented in Epic 1)
+- [x] Method uses section marker pattern to identify and remove procedure block
+- [x] Handle case where procedure doesn't exist (idempotent - returns nil)
+- [x] Handle case where procedure exists but ownership markers don't match
+- [x] Unit tests for drop functionality already exist
+
+### Task 3: Add danger zone UI to Settings screen
+
+**Files**: `internal/adapter/ui/database_settings.go`, `internal/adapter/ui/styles/styles.go`, `internal/adapter/ui/model.go`
+
+**Implementation approach**:
+- Add "Danger Zone" section in Settings screen with red/warning styling
+- Add "Delete My Procedure" option (activated via D key)
+- Show confirmation dialog before executing
+- Display current procedure name being deleted (e.g., `TRACE_MESSAGE_BARNACLE`)
+
+**UI Flow**:
+1. User presses S to open Settings
+2. User scrolls to Danger Zone section
+3. User presses D to select "Delete My Procedure"
+4. Confirmation dialog shows: "This will delete your procedure `TRACE_MESSAGE_BARNACLE`. You can regenerate it by restarting OmniView."
+5. If confirmed (Y key), call `DropSubscriberProcedure` and show success/error
+6. If success, procedure is removed from package
+
+- [x] Add `DangerZoneStyle` in `styles/styles.go` (red/warning styling)
+- [x] Add danger zone section to Settings screen with hint "Press D to delete your subscriber procedure"
+- [x] Add "D" key handler to trigger drop procedure confirmation
+- [x] Add confirmation modal `viewDropProcedureConfirmModal()` showing procedure name
+- [x] Wire up to `ProcedureGenerator.DropSubscriberProcedure()` via async command pattern
+- [x] Handle success/error feedback to user via dialog
+- [x] Add drop procedure confirm modal rendering in model.go View()
+
+### Task 4: Handle edge cases and errors
+
+- [x] Handle Oracle errors during procedure drop (package invalidation, etc.) - error shown in dialog
+- [x] Handle case where subscriber has no procedure (no-op, show "no procedure to delete")
+- [x] Handle case where subscriber is not registered (Danger zone section only shows when subscriber has funny name)
+- [x] Unit tests for error scenarios already exist in procedure_generator_test.go
+
+### Task 5: Verify build and tests
+
+- [x] Run `make test` to verify all tests pass
+- [x] Run `make build` to verify no compilation errors
+
+---
+
+## Dev Notes
+
+### Technical Context
+
+**From Epic 1 completed work**:
+- `subscriber.FunnyName()` returns the auto-assigned funny name (e.g., "BARNACLE")
+- Generated procedures are stored inside `OMNI_TRACER_API` package with section markers
+- `ProcedureGenerator` handles procedure creation with `EnsureSubscriberProcedure()`
+- The package uses `DeployFile()` to redeploy the full package when procedures change
+
+**Ownership markers** (from procedure_generator.go):
+```sql
+-- @SECTION: SUBSCRIBER_GENERATED_METHOD : BARNACLE
+PROCEDURE TRACE_MESSAGE_BARNACLE(
+    message_   IN CLOB,
+    log_level_ IN VARCHAR2 DEFAULT 'INFO',
+    process_name_  IN VARCHAR2 DEFAULT NULL
+)
+IS
+BEGIN
+    Enqueue_Event___(
+        process_name_     => process_name_,
+        log_level_        => log_level_,
+        payload           => message_,
+        subscriber_name_  => 'BARNACLE'
+    );
+END TRACE_MESSAGE_BARNACLE;
+-- @END_SECTION: SUBSCRIBER_GENERATED_METHOD : BARNACLE
+```
+
+**Drop approach**:
+- Fetch current package body source via `FetchPackageBody()`
+- Use `replaceProcedureBlock()` or similar to remove the subscriber's section
+- Redeploy the updated package body via `DeployPackageBody()`
+
+### File Structure
+
+```
+internal/
+├── adapter/
+│   └── ui/
+│       ├── database_settings.go        # [MODIFY] Add danger zone
+│       └── styles/
+│           └── styles.go              # [MODIFY] Add DangerZoneStyle
+├── service/
+│   └── subscribers/
+│       ├── procedure_generator.go     # [MODIFY] Add DropSubscriberProcedure
+│       └── procedure_generator_test.go # [MODIFY] Add drop tests
+```
+
+### Testing Approach
+
+- Test `DropSubscriberProcedure` with existing procedure (should succeed)
+- Test `DropSubscriberProcedure` with non-existent procedure (should return nil - idempotent)
+- Test `DropSubscriberProcedure` with procedure owned by another subscriber (should handle gracefully)
+- Test Settings UI danger zone flow with confirmation dialog
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story-3.1]
+- [Source: _bmad-output/planning-artifacts/architecture.md#Pattern-4]
+- [Source: internal/service/subscribers/procedure_generator.go] — existing procedure generation
+- [Source: internal/adapter/ui/database_settings.go] — Settings screen
+- [Source: docs/ARCHITECTURE_AND_MULTI_SUBSCRIBER_PLAN.md]
+
+---
+
+## Dev Agent Record
+
+### Implementation Plan
+
+**Approach**: Added danger zone UI to Settings screen with D key to trigger drop procedure confirmation.
+
+**Files Modified**:
+- `internal/adapter/ui/styles/styles.go` — added `DangerZoneStyle` (red/bold)
+- `internal/adapter/ui/database_settings.go` — added danger zone state, D key handler, drop confirmation modal, async command wiring
+- `internal/adapter/ui/messages.go` — added `dropSubscriberProcedureMsg` and `dropSubscriberProcedureResultMsg`
+- `internal/adapter/ui/model.go` — added `showDropProcedureConfirm` handling in View()
+- `internal/service/subscribers/subscriber_service.go` — added `ProcedureGenerator()` accessor method
+
+**Key Implementation Details**:
+- `DropSubscriberProcedure` was already implemented in Epic 1 (procedure_generator.go:217)
+- Added `DangerZoneStyle` with ErrorColor and Bold for visual prominence
+- "Danger Zone" section only appears when subscriber has a funny name
+- D key triggers confirmation modal showing procedure name
+- Y key confirms and calls `DropSubscriberProcedure` asynchronously
+- Success/error shown in dialog with appropriate message
+
+### Debug Log
+
+- Added `showDropProcedureConfirm` and `dropProcedureConfirmMsg` fields to `databaseSettingsState`
+- Added `dropSubscriberProcedureMsg` and `dropSubscriberProcedureResultMsg` message types
+- Added `viewDropProcedureConfirmModal()` method for confirmation dialog rendering
+- Added `ProcedureGenerator()` accessor to `SubscriberService` for UI access
+- Modal rendering added to main View() in model.go after delete confirm check
+
+### Completion Notes
+
+✅ Story 3-1 completed: Drop Subscriber Procedure (Danger Zone) implemented with:
+- `DangerZoneStyle` added to `styles/styles.go` (red foreground, bold)
+- Danger zone section in Settings screen (only shown when subscriber has funny name)
+- "Press D to delete your subscriber procedure" hint in UI
+- D key handler triggers confirmation modal
+- `viewDropProcedureConfirmModal()` shows procedure name and warning
+- Y confirms and calls `DropSubscriberProcedure` asynchronously
+- Error/success feedback via dialog
+- `make test` ✅ — all tests pass
+- `make build` ✅ — binary built successfully
+
+---
+
+## File List
+
+**Modified:**
+- `internal/adapter/ui/styles/styles.go` — added `DangerZoneStyle`
+- `internal/adapter/ui/database_settings.go` — added danger zone UI, D key handler, confirmation modal
+- `internal/adapter/ui/messages.go` — added `dropSubscriberProcedureMsg`, `dropSubscriberProcedureResultMsg`
+- `internal/adapter/ui/model.go` — added drop procedure confirm modal rendering in View()
+- `internal/service/subscribers/subscriber_service.go` — added `ProcedureGenerator()` accessor method
+
+**Created:**
+- (none — `DropSubscriberProcedure` already existed from Epic 1)
+
+---
+
+## Change Log
+
+- **2026-05-12**: Story created — ready for dev-story execution
+- **2026-05-12**: Implementation started — DangerZoneStyle, danger zone UI, D key handler, confirmation modal, async command wiring
+- **2026-05-12**: Implementation complete — make test and make build passing
+- **2026-05-12**: Story done — ready for review
+
+---
+
+## Status History
+
+| Date | Status | Notes |
+|------|--------|-------|
+| 2026-05-12 | ready-for-dev | Story created from Epic 3 requirements |
+| 2026-05-12 | in-progress | Implementation started |
+| 2026-05-12 | done | Implementation complete; make test and make build passing |

--- a/internal/adapter/ui/chrome.go
+++ b/internal/adapter/ui/chrome.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"OmniView/internal/adapter/ui/styles"
+	"image/color"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -213,7 +214,7 @@ type embeddedFieldOptions struct {
 	Width       int
 	Focused     bool
 	Required    bool
-	BorderColor string
+	BorderColor color.Color
 	FooterText  string
 }
 
@@ -236,8 +237,8 @@ func renderEmbeddedField(opts embeddedFieldOptions) string {
 		borderStyle = styles.FieldFocusedBorderStyle
 		labelStyle = styles.OnboardingActiveLabelStyle
 	}
-	if opts.BorderColor != "" {
-		borderStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(opts.BorderColor))
+	if opts.BorderColor != nil {
+		borderStyle = lipgloss.NewStyle().Foreground(opts.BorderColor)
 	}
 
 	label := labelStyle.Render(opts.Label)

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -35,6 +35,7 @@ type databaseSettingsState struct {
 	// Danger zone fields
 	showDropProcedureConfirm bool
 	dropProcedureConfirmMsg  string
+	dropProcedureTarget      string
 }
 
 // ==========================================
@@ -130,6 +131,7 @@ func (m *Model) closeDatabaseSettings() {
 	m.dbSettings.editingOriginalStorageKey = ""
 	m.dbSettings.showDropProcedureConfirm = false
 	m.dbSettings.dropProcedureConfirmMsg = ""
+	m.dbSettings.dropProcedureTarget = ""
 }
 
 // ==========================================
@@ -206,19 +208,20 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 				m.dbSettings.showDropProcedureConfirm = false
 				m.dbSettings.dropProcedureConfirmMsg = ""
 				return m, func() tea.Msg {
-					return dropSubscriberProcedureMsg{}
+					return dropSubscriberProcedureMsg{funnyName: m.dbSettings.dropProcedureTarget}
 				}
 			}
 			if isConfirmKey(msg) {
 				m.dbSettings.showDropProcedureConfirm = false
 				m.dbSettings.dropProcedureConfirmMsg = ""
 				return m, func() tea.Msg {
-					return dropSubscriberProcedureMsg{}
+					return dropSubscriberProcedureMsg{funnyName: m.dbSettings.dropProcedureTarget}
 				}
 			}
 			if isCancelKey(msg) {
 				m.dbSettings.showDropProcedureConfirm = false
 				m.dbSettings.dropProcedureConfirmMsg = ""
+				m.dbSettings.dropProcedureTarget = ""
 			}
 			return m, nil
 		}
@@ -255,9 +258,10 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 				m.dbSettings.showDeleteConfirm = true
 			}
 			return m, nil
-		case "d":
+		case "ctrl+d":
 			if m.subscriber != nil && m.subscriber.FunnyName() != "" {
-				m.dbSettings.dropProcedureConfirmMsg = fmt.Sprintf("This will delete your procedure TRACE_MESSAGE_%s. You can regenerate it by restarting OmniView.", m.subscriber.FunnyName())
+				m.dbSettings.dropProcedureTarget = m.subscriber.FunnyName()
+				m.dbSettings.dropProcedureConfirmMsg = fmt.Sprintf("This will delete your procedure TRACE_MESSAGE_%s. You can regenerate it by restarting OmniView.", m.dbSettings.dropProcedureTarget)
 				m.dbSettings.showDropProcedureConfirm = true
 			}
 			return m, nil
@@ -341,10 +345,7 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 		return m, nil
 
 	case dropSubscriberProcedureMsg:
-		funnyName := ""
-		if m.subscriber != nil {
-			funnyName = m.subscriber.FunnyName()
-		}
+		funnyName := msg.funnyName
 		if funnyName == "" {
 			m.dbSettings.dialogMsg = "No subscriber procedure to delete."
 			m.dbSettings.dialogIsError = true
@@ -407,7 +408,7 @@ func (m *Model) viewDatabaseSettings() string {
 			Label:       "Current Connection",
 			Value:       activeSummary,
 			Width:       innerWidth,
-			BorderColor: "#F0C802",
+			BorderColor: styles.ConnectionBorderColor,
 		}),
 		"",
 		styles.SectionTitleStyle.Render("Stored Connections"),
@@ -431,17 +432,22 @@ func (m *Model) viewDatabaseSettings() string {
 
 	// Danger Zone for subscriber procedure deletion
 	if m.subscriber != nil && m.subscriber.FunnyName() != "" {
+		dangerContent := styles.SubtitleStyle.Render("Press Ctrl+D to delete your subscriber procedure.")
 		parts = append(parts,
 			"",
-			styles.DangerZoneStyle.Render("Danger Zone"),
-			styles.SubtitleStyle.Width(innerWidth).Render("Press D to delete your subscriber procedure."),
+			renderEmbeddedField(embeddedFieldOptions{
+				Label:       "Danger Zone",
+				Value:       dangerContent,
+				Width:       innerWidth,
+				BorderColor: styles.ErrorColor,
+			}),
 		)
 	}
 
 	parts = append(
 		parts,
 		"",
-		styles.OnboardingHintStyle.Width(innerWidth).Render("↑/↓ Select  •  Enter Connect  •  A Add  •  E Edit  •  X Delete  •  D Nuke Procedure  •  Esc Back"),
+		styles.OnboardingHintStyle.Width(innerWidth).Render("↑/↓ Select  •  Enter Connect  •  A Add  •  E Edit  •  X Delete  •  Esc Back"),
 	)
 
 	panel := renderFramedPanel("Connections", panelWidth, panelTypeInfo, lipgloss.JoinVertical(lipgloss.Left, parts...))
@@ -483,10 +489,7 @@ func (m *Model) viewDeleteConfirmModal() string {
 
 // viewDropProcedureConfirmModal: renders a standalone warning dialog for confirming procedure deletion.
 func (m *Model) viewDropProcedureConfirmModal() string {
-	funnyName := ""
-	if m.subscriber != nil {
-		funnyName = m.subscriber.FunnyName()
-	}
+	funnyName := m.dbSettings.dropProcedureTarget
 
 	modalWidth := max(min(m.width-20, 60), 44)
 	innerWidth := max(modalWidth-4, 24)

--- a/internal/adapter/ui/database_settings.go
+++ b/internal/adapter/ui/database_settings.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"unicode"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -29,7 +30,11 @@ type databaseSettingsState struct {
 	showDeleteConfirm         bool
 	addForm                   AddDatabaseForm
 	dialogMsg                 string
+	dialogIsError             bool
 	showDialog                bool
+	// Danger zone fields
+	showDropProcedureConfirm bool
+	dropProcedureConfirmMsg  string
 }
 
 // ==========================================
@@ -64,6 +69,22 @@ func settingsPanelWidth(termWidth int) int {
 	contentWidth, _ := screenContentSize(termWidth, 1)
 	preferredWidth := max(min(termWidth-10, 92), 60)
 	return min(preferredWidth, max(contentWidth, 1))
+}
+
+func keyMatchesRune(msg tea.KeyPressMsg, want rune) bool {
+	if unicode.ToLower(msg.Code) == want {
+		return true
+	}
+	text := []rune(msg.Text)
+	return len(text) == 1 && unicode.ToLower(text[0]) == want
+}
+
+func isConfirmKey(msg tea.KeyPressMsg) bool {
+	return keyMatchesRune(msg, 'y')
+}
+
+func isCancelKey(msg tea.KeyPressMsg) bool {
+	return keyMatchesRune(msg, 'n') || keyMatchesRune(msg, 'q') || msg.String() == "esc"
 }
 
 // initDatabaseSettings: initializes the database settings panel with the list of databases and marks it visible.
@@ -103,9 +124,12 @@ func (m *Model) closeDatabaseSettings() {
 	m.dbSettings.showAddForm = false
 	m.dbSettings.showDialog = false
 	m.dbSettings.dialogMsg = ""
+	m.dbSettings.dialogIsError = false
 	m.dbSettings.editingID = ""
 	m.dbSettings.addForm.editingDB = nil
 	m.dbSettings.editingOriginalStorageKey = ""
+	m.dbSettings.showDropProcedureConfirm = false
+	m.dbSettings.dropProcedureConfirmMsg = ""
 }
 
 // ==========================================
@@ -159,9 +183,42 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 				return m, func() tea.Msg {
 					return deleteConfirmedMsg{id: m.dbSettings.deleteConfirmID}
 				}
-			case "n", "esc", "q":
+			}
+			if isConfirmKey(msg) {
+				return m, func() tea.Msg {
+					return deleteConfirmedMsg{id: m.dbSettings.deleteConfirmID}
+				}
+			}
+			if isCancelKey(msg) {
 				m.dbSettings.showDeleteConfirm = false
 				m.dbSettings.deleteConfirmID = ""
+			}
+			return m, nil
+		}
+
+		// While the drop procedure confirm modal is open, only allow confirm/cancel keys.
+		if m.dbSettings.showDropProcedureConfirm {
+			switch msg.String() {
+			case "ctrl+c":
+				m.cancel()
+				return m, tea.Quit
+			case "y":
+				m.dbSettings.showDropProcedureConfirm = false
+				m.dbSettings.dropProcedureConfirmMsg = ""
+				return m, func() tea.Msg {
+					return dropSubscriberProcedureMsg{}
+				}
+			}
+			if isConfirmKey(msg) {
+				m.dbSettings.showDropProcedureConfirm = false
+				m.dbSettings.dropProcedureConfirmMsg = ""
+				return m, func() tea.Msg {
+					return dropSubscriberProcedureMsg{}
+				}
+			}
+			if isCancelKey(msg) {
+				m.dbSettings.showDropProcedureConfirm = false
+				m.dbSettings.dropProcedureConfirmMsg = ""
 			}
 			return m, nil
 		}
@@ -196,6 +253,12 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 				selected := m.dbSettings.databases[cursor]
 				m.dbSettings.deleteConfirmID = selected.ID()
 				m.dbSettings.showDeleteConfirm = true
+			}
+			return m, nil
+		case "d":
+			if m.subscriber != nil && m.subscriber.FunnyName() != "" {
+				m.dbSettings.dropProcedureConfirmMsg = fmt.Sprintf("This will delete your procedure TRACE_MESSAGE_%s. You can regenerate it by restarting OmniView.", m.subscriber.FunnyName())
+				m.dbSettings.showDropProcedureConfirm = true
 			}
 			return m, nil
 		case "enter":
@@ -236,6 +299,7 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 	case dbValidationResultMsg:
 		if msg.err != nil {
 			m.dbSettings.dialogMsg = msg.err.Error()
+			m.dbSettings.dialogIsError = true
 			m.dbSettings.showDialog = true
 			return m, nil
 		}
@@ -245,6 +309,7 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 	case dbSwitchResultMsg:
 		if msg.err != nil {
 			m.dbSettings.dialogMsg = msg.err.Error()
+			m.dbSettings.dialogIsError = true
 			m.dbSettings.showDialog = true
 			return m, nil
 		}
@@ -254,6 +319,7 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 		// Prevent deletion of active connection
 		if msg.id == m.dbSettings.activeID {
 			m.dbSettings.dialogMsg = "Cannot delete the currently active database connection."
+			m.dbSettings.dialogIsError = true
 			m.dbSettings.showDialog = true
 			m.dbSettings.showDeleteConfirm = false
 			m.dbSettings.deleteConfirmID = ""
@@ -265,12 +331,46 @@ func (m *Model) updateDatabaseSettings(msg tea.Msg) (*Model, tea.Cmd) {
 			m.dbSettings.showDeleteConfirm = false
 			m.dbSettings.deleteConfirmID = ""
 			m.dbSettings.dialogMsg = err.Error()
+			m.dbSettings.dialogIsError = true
 			m.dbSettings.showDialog = true
 			return m, nil
 		}
 		m.dbSettings.showDeleteConfirm = false
 		m.dbSettings.deleteConfirmID = ""
 		m.reloadDatabaseList()
+		return m, nil
+
+	case dropSubscriberProcedureMsg:
+		funnyName := ""
+		if m.subscriber != nil {
+			funnyName = m.subscriber.FunnyName()
+		}
+		if funnyName == "" {
+			m.dbSettings.dialogMsg = "No subscriber procedure to delete."
+			m.dbSettings.dialogIsError = true
+			m.dbSettings.showDialog = true
+			return m, nil
+		}
+		return m, func() tea.Msg {
+			var dropErr error
+			if m.subscriberService == nil {
+				dropErr = fmt.Errorf("drop subscriber procedure: %w", domain.ErrProcedureGeneration)
+			} else {
+				dropErr = m.subscriberService.DropSubscriberProcedure(m.ctx, funnyName)
+			}
+			return dropSubscriberProcedureResultMsg{err: dropErr}
+		}
+
+	case dropSubscriberProcedureResultMsg:
+		if msg.err != nil {
+			m.dbSettings.dialogMsg = fmt.Sprintf("Failed to delete procedure: %v", msg.err)
+			m.dbSettings.dialogIsError = true
+			m.dbSettings.showDialog = true
+			return m, nil
+		}
+		m.dbSettings.dialogMsg = "Procedure deleted successfully. Restart OmniView to regenerate."
+		m.dbSettings.dialogIsError = false
+		m.dbSettings.showDialog = true
 		return m, nil
 
 	case tea.WindowSizeMsg:
@@ -317,18 +417,31 @@ func (m *Model) viewDatabaseSettings() string {
 	}
 
 	if m.dbSettings.showDialog && m.dbSettings.dialogMsg != "" {
+		dialogLine := styles.OnboardingSavedStyle.Render(m.dbSettings.dialogMsg)
+		if m.dbSettings.dialogIsError {
+			dialogLine = styles.OnboardingErrorStyle.Render("Error: " + m.dbSettings.dialogMsg)
+		}
 		parts = append(
 			parts,
 			"",
-			styles.OnboardingErrorStyle.Render("Error: "+m.dbSettings.dialogMsg),
+			dialogLine,
 			styles.SubtitleStyle.Width(innerWidth).Render("Press Esc to dismiss the message and stay on this screen."),
+		)
+	}
+
+	// Danger Zone for subscriber procedure deletion
+	if m.subscriber != nil && m.subscriber.FunnyName() != "" {
+		parts = append(parts,
+			"",
+			styles.DangerZoneStyle.Render("Danger Zone"),
+			styles.SubtitleStyle.Width(innerWidth).Render("Press D to delete your subscriber procedure."),
 		)
 	}
 
 	parts = append(
 		parts,
 		"",
-		styles.OnboardingHintStyle.Width(innerWidth).Render("↑/↓ Select  •  Enter Connect  •  A Add  •  E Edit  •  X Delete  •  Esc Back"),
+		styles.OnboardingHintStyle.Width(innerWidth).Render("↑/↓ Select  •  Enter Connect  •  A Add  •  E Edit  •  X Delete  •  D Nuke Procedure  •  Esc Back"),
 	)
 
 	panel := renderFramedPanel("Connections", panelWidth, panelTypeInfo, lipgloss.JoinVertical(lipgloss.Left, parts...))
@@ -368,6 +481,34 @@ func (m *Model) viewDeleteConfirmModal() string {
 	return renderFramedPanel("Confirm Delete", modalWidth, panelTypeWarning, content)
 }
 
+// viewDropProcedureConfirmModal: renders a standalone warning dialog for confirming procedure deletion.
+func (m *Model) viewDropProcedureConfirmModal() string {
+	funnyName := ""
+	if m.subscriber != nil {
+		funnyName = m.subscriber.FunnyName()
+	}
+
+	modalWidth := max(min(m.width-20, 60), 44)
+	innerWidth := max(modalWidth-4, 24)
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		styles.DangerZoneStyle.Width(innerWidth).Render("Delete Subscriber Procedure"),
+		"",
+		styles.BodyTextStyle.Width(innerWidth).Render("Are you sure you want to delete your procedure?"),
+		"",
+		lipgloss.NewStyle().Foreground(styles.AccentColor).Bold(true).Width(innerWidth).Render("  TRACE_MESSAGE_"+funnyName),
+		"",
+		styles.SubtitleStyle.Width(innerWidth).Render("You can regenerate it by restarting OmniView."),
+		"",
+		lipgloss.NewStyle().Foreground(styles.SuccessColor).Bold(true).Render("Y")+" "+
+			styles.BodyTextStyle.Render("Confirm")+"   "+
+			styles.SubtitleStyle.Render("N / Esc  Cancel"),
+	)
+
+	return renderFramedPanel("Confirm Delete", modalWidth, panelTypeWarning, content)
+}
+
 // ==========================================
 // Database Switching
 // ==========================================
@@ -377,6 +518,7 @@ func (m *Model) showDatabaseSwitchError(err error) (*Model, tea.Cmd) {
 	m.loading.err = err
 	m.dbSettings.visible = true
 	m.dbSettings.dialogMsg = err.Error()
+	m.dbSettings.dialogIsError = true
 	m.dbSettings.showDialog = true
 	return m, nil
 }

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -293,6 +293,7 @@ func TestUpdateDatabaseSettings_DropProcedureConfirm_UppercaseYExecutesDropAndSh
 		t.Fatalf("NewSubscriberWithFunnyName: %v", err)
 	}
 	m.subscriber = subscriber
+	m.dbSettings.dropProcedureTarget = "BARNACLE"
 
 	updated, cmd := m.updateDatabaseSettings(makeCharPress("Y"))
 	if cmd == nil {
@@ -308,7 +309,7 @@ func TestUpdateDatabaseSettings_DropProcedureConfirm_UppercaseYExecutesDropAndSh
 		t.Fatal("expected async drop command")
 	}
 
-	msg = cmd()
+	msg = cmd() // msg is dropSubscriberProcedureResultMsg
 	updated, _ = updated.updateDatabaseSettings(msg)
 
 	if procGen.dropCalledWith != "BARNACLE" {
@@ -335,12 +336,13 @@ func TestUpdateDatabaseSettings_DropProcedureConfirm_ShowsErrorWhenProcedureDrop
 	}
 	m.subscriber = subscriber
 
-	updated, cmd := m.updateDatabaseSettings(dropSubscriberProcedureMsg{})
+	// Manually trigger dropSubscriberProcedureMsg with a valid funnyName
+	updated, cmd := m.updateDatabaseSettings(dropSubscriberProcedureMsg{funnyName: "BARNACLE"})
 	if cmd == nil {
 		t.Fatal("expected async drop command")
 	}
 
-	msg := cmd()
+	msg := cmd() // This returns dropSubscriberProcedureResultMsg with an error because m.subscriberService is nil
 	updated, _ = updated.updateDatabaseSettings(msg)
 
 	if !updated.dbSettings.showDialog {

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -4,6 +4,7 @@ import (
 	"OmniView/internal/adapter/storage/boltdb"
 	"OmniView/internal/core/domain"
 	"OmniView/internal/core/ports"
+	"OmniView/internal/service/subscribers"
 	"OmniView/internal/service/tracer"
 
 	"context"
@@ -26,6 +27,32 @@ type MockDatabaseRepository struct {
 
 	connectError error
 	closeError   error
+}
+
+type stubProcedureGeneratorRepo struct {
+	dropCalledWith string
+	dropErr        error
+}
+
+func (s *stubProcedureGeneratorRepo) ReserveFunnyName(ctx context.Context, subscriber *domain.Subscriber) (string, bool, error) {
+	return "", false, nil
+}
+
+func (s *stubProcedureGeneratorRepo) ReleaseFunnyName(ctx context.Context, funnyName string) error {
+	return nil
+}
+
+func (s *stubProcedureGeneratorRepo) EnsureOwnedFunnyName(ctx context.Context, subscriber *domain.Subscriber) (bool, error) {
+	return false, nil
+}
+
+func (s *stubProcedureGeneratorRepo) EnsureSubscriberProcedure(ctx context.Context, subscriber *domain.Subscriber) error {
+	return nil
+}
+
+func (s *stubProcedureGeneratorRepo) DropSubscriberProcedure(ctx context.Context, funnyName string) error {
+	s.dropCalledWith = funnyName
+	return s.dropErr
 }
 
 // NewMockDatabaseRepository creates a MockDatabaseRepository with configurable behavior.
@@ -250,6 +277,80 @@ func TestHandleSettingsSetAsMain_ServiceCleanup_WithExistingServices(t *testing.
 	// Assert command is returned
 	if cmd == nil {
 		t.Error("expected non-nil command to be returned")
+	}
+}
+
+func TestUpdateDatabaseSettings_DropProcedureConfirm_UppercaseYExecutesDropAndShowsSuccess(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModelForSettings(t)
+	procGen := &stubProcedureGeneratorRepo{}
+	m.subscriberService = subscribers.NewSubscriberService(NewMockDatabaseRepository(), nil, procGen)
+	m.dbSettings.showDropProcedureConfirm = true
+
+	subscriber, err := domain.NewSubscriberWithFunnyName("TEST_SUB", "BARNACLE", domain.DefaultBatchSize, domain.DefaultWaitTime)
+	if err != nil {
+		t.Fatalf("NewSubscriberWithFunnyName: %v", err)
+	}
+	m.subscriber = subscriber
+
+	updated, cmd := m.updateDatabaseSettings(makeCharPress("Y"))
+	if cmd == nil {
+		t.Fatal("expected confirm command for uppercase Y")
+	}
+	if updated.dbSettings.showDropProcedureConfirm {
+		t.Fatal("expected drop confirmation modal to close after confirmation")
+	}
+
+	msg := cmd()
+	updated, cmd = updated.updateDatabaseSettings(msg)
+	if cmd == nil {
+		t.Fatal("expected async drop command")
+	}
+
+	msg = cmd()
+	updated, _ = updated.updateDatabaseSettings(msg)
+
+	if procGen.dropCalledWith != "BARNACLE" {
+		t.Fatalf("expected drop to target BARNACLE, got %q", procGen.dropCalledWith)
+	}
+	if !updated.dbSettings.showDialog {
+		t.Fatal("expected success dialog to be shown")
+	}
+	if updated.dbSettings.dialogIsError {
+		t.Fatal("expected success dialog, got error dialog")
+	}
+	if updated.dbSettings.dialogMsg == "" {
+		t.Fatal("expected success dialog message to be set")
+	}
+}
+
+func TestUpdateDatabaseSettings_DropProcedureConfirm_ShowsErrorWhenProcedureDropUnavailable(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModelForSettings(t)
+	subscriber, err := domain.NewSubscriberWithFunnyName("TEST_SUB", "BARNACLE", domain.DefaultBatchSize, domain.DefaultWaitTime)
+	if err != nil {
+		t.Fatalf("NewSubscriberWithFunnyName: %v", err)
+	}
+	m.subscriber = subscriber
+
+	updated, cmd := m.updateDatabaseSettings(dropSubscriberProcedureMsg{})
+	if cmd == nil {
+		t.Fatal("expected async drop command")
+	}
+
+	msg := cmd()
+	updated, _ = updated.updateDatabaseSettings(msg)
+
+	if !updated.dbSettings.showDialog {
+		t.Fatal("expected error dialog to be shown")
+	}
+	if !updated.dbSettings.dialogIsError {
+		t.Fatal("expected error dialog styling")
+	}
+	if updated.dbSettings.dialogMsg == "" {
+		t.Fatal("expected error dialog message to be set")
 	}
 }
 

--- a/internal/adapter/ui/main_screen.go
+++ b/internal/adapter/ui/main_screen.go
@@ -100,7 +100,8 @@ func sanitizeLogString(s string) string {
 // updateMain handles messages when screen == "main".
 func (m *Model) updateMain(msg tea.Msg) (*Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case dbValidationResultMsg, dbSwitchResultMsg, deleteConfirmedMsg, editDatabaseMsg:
+	case dbValidationResultMsg, dbSwitchResultMsg, deleteConfirmedMsg, editDatabaseMsg,
+		dropSubscriberProcedureMsg, dropSubscriberProcedureResultMsg:
 		if m.dbSettings.visible {
 			return m.updateDatabaseSettings(msg)
 		}

--- a/internal/adapter/ui/messages.go
+++ b/internal/adapter/ui/messages.go
@@ -106,6 +106,14 @@ type deleteConfirmedMsg struct {
 	id string
 }
 
+// dropSubscriberProcedureMsg requests dropping the current subscriber's procedure.
+type dropSubscriberProcedureMsg struct{}
+
+// dropSubscriberProcedureResultMsg returns the result of a drop procedure attempt.
+type dropSubscriberProcedureResultMsg struct {
+	err error
+}
+
 // webhookConfigSavedMsg is returned after attempting to save or clear the webhook configuration.
 type webhookConfigSavedMsg struct {
 	config  *domain.WebhookConfig

--- a/internal/adapter/ui/messages.go
+++ b/internal/adapter/ui/messages.go
@@ -107,7 +107,9 @@ type deleteConfirmedMsg struct {
 }
 
 // dropSubscriberProcedureMsg requests dropping the current subscriber's procedure.
-type dropSubscriberProcedureMsg struct{}
+type dropSubscriberProcedureMsg struct {
+	funnyName string
+}
 
 // dropSubscriberProcedureResultMsg returns the result of a drop procedure attempt.
 type dropSubscriberProcedureResultMsg struct {

--- a/internal/adapter/ui/model.go
+++ b/internal/adapter/ui/model.go
@@ -447,6 +447,8 @@ func (m *Model) View() tea.View {
 					content = renderCenteredOverlay(content, m.dbSettings.addForm.Modal(), m.width, m.height)
 				} else if m.dbSettings.showDeleteConfirm {
 					content = renderCenteredOverlay(content, m.viewDeleteConfirmModal(), m.width, m.height)
+				} else if m.dbSettings.showDropProcedureConfirm {
+					content = renderCenteredOverlay(content, m.viewDropProcedureConfirmModal(), m.width, m.height)
 				}
 			} else if m.webhookSettings.visible {
 				content = renderCenteredOverlay(content, m.viewWebhookSettings(), m.width, m.height)

--- a/internal/adapter/ui/styles/styles.go
+++ b/internal/adapter/ui/styles/styles.go
@@ -216,6 +216,10 @@ var (
 				Foreground(SuccessColor).
 				Bold(true)
 
+	DangerZoneStyle = lipgloss.NewStyle().
+				Foreground(ErrorColor).
+				Bold(true)
+
 	FieldBorderStyle = lipgloss.NewStyle().
 				Foreground(SurfaceColor)
 

--- a/internal/adapter/ui/webhook_settings.go
+++ b/internal/adapter/ui/webhook_settings.go
@@ -252,7 +252,7 @@ func (m *Model) viewWebhookSettings() string {
 			Label:       "Current Webhook",
 			Value:       currentWebhook,
 			Width:       innerWidth,
-			BorderColor: "#F0C802",
+			BorderColor: styles.ConnectionBorderColor,
 		}))
 	}
 

--- a/internal/service/subscribers/procedure_generator.go
+++ b/internal/service/subscribers/procedure_generator.go
@@ -220,18 +220,12 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 	}
 
 	procedureName := buildProcedureName(funnyName)
-	exists, err := pg.db.ProcedureExists(ctx, domain.OmniTracerPackage, procedureName)
-	if err != nil {
-		return fmt.Errorf("DropSubscriberProcedure: failed to check procedure existence: %w", err)
-	}
-	if !exists {
-		return nil
-	}
-
 	packageSpec, packageBody, err := pg.fetchCurrentPackageSource(ctx)
 	if err != nil {
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
 	}
+	originalSpec := packageSpec
+	originalBody := packageBody
 
 	packageSpec, err = removeProcedureDeclaration(packageSpec, procedureName)
 	if err != nil {
@@ -240,6 +234,9 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 	packageBody, err = removeProcedureBody(packageBody, procedureName)
 	if err != nil {
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
+	}
+	if packageSpec == originalSpec && packageBody == originalBody {
+		return fmt.Errorf("DropSubscriberProcedure: %w", domain.ErrProcedureNotFound)
 	}
 
 	if err := pg.db.DeployFile(ctx, renderPackageDeploymentSQL(packageSpec, packageBody)); err != nil {

--- a/internal/service/subscribers/procedure_generator.go
+++ b/internal/service/subscribers/procedure_generator.go
@@ -236,7 +236,8 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
 	}
 	if packageSpec == originalSpec && packageBody == originalBody {
-		return fmt.Errorf("DropSubscriberProcedure: %w", domain.ErrProcedureNotFound)
+		// if the procedure was not found, we can skip deployment which would be a no-op
+		return nil
 	}
 
 	if err := pg.db.DeployFile(ctx, renderPackageDeploymentSQL(packageSpec, packageBody)); err != nil {

--- a/internal/service/subscribers/procedure_generator.go
+++ b/internal/service/subscribers/procedure_generator.go
@@ -224,8 +224,6 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 	if err != nil {
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
 	}
-	originalSpec := packageSpec
-	originalBody := packageBody
 
 	originalSpec, originalBody := packageSpec, packageBody
 
@@ -236,10 +234,6 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 	packageBody, err = removeProcedureBody(packageBody, procedureName)
 	if err != nil {
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
-	}
-	if packageSpec == originalSpec && packageBody == originalBody {
-		// if the procedure was not found, we can skip deployment which would be a no-op
-		return nil
 	}
 
 	if packageSpec == originalSpec && packageBody == originalBody {

--- a/internal/service/subscribers/procedure_generator_test.go
+++ b/internal/service/subscribers/procedure_generator_test.go
@@ -420,6 +420,89 @@ END OMNI_TRACER_API;`),
 	}
 }
 
+func TestProcedureGenerator_DropSubscriberProcedure_DropsFromSourceEvenWhenProcedureExistsQueryReturnsFalse(t *testing.T) {
+	stub := &stubDBRepo{
+		procedureExists: map[string]bool{buildProcedureName("BARNACLE"): false},
+		packageSpecSource: splitLines(`CREATE OR REPLACE PACKAGE OMNI_TRACER_API AS
+-- @SECTION: SUBSCRIBER_GENERATED_METHOD : TEST_SUB
+    PROCEDURE TRACE_MESSAGE_BARNACLE(
+        message_   IN CLOB,
+        log_level_ IN VARCHAR2 DEFAULT 'INFO',
+        process_name_  IN VARCHAR2 DEFAULT NULL
+    );
+-- @END_SECTION: SUBSCRIBER_GENERATED_METHOD : TEST_SUB
+END OMNI_TRACER_API;`),
+		packageBodySource: splitLines(`CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
+    PROCEDURE Enqueue_Event___ (
+        process_name_       IN VARCHAR2,
+        log_level_          IN VARCHAR2,
+        payload             IN CLOB,
+        additional_props_   IN CLOB DEFAULT NULL,
+        subscriber_name_    IN VARCHAR2 DEFAULT NULL )
+    IS
+    BEGIN
+        NULL;
+    END Enqueue_Event___;
+
+-- @SECTION: SUBSCRIBER_GENERATED_METHOD : TEST_SUB
+    PROCEDURE TRACE_MESSAGE_BARNACLE(
+        message_   IN CLOB,
+        log_level_ IN VARCHAR2 DEFAULT 'INFO',
+        process_name_  IN VARCHAR2 DEFAULT NULL
+    )
+    IS
+    BEGIN
+        Enqueue_Event___(
+            process_name_     => process_name_,
+            log_level_        => log_level_,
+            payload           => message_,
+            subscriber_name_  => 'BARNACLE'
+        );
+    END TRACE_MESSAGE_BARNACLE;
+-- @END_SECTION: SUBSCRIBER_GENERATED_METHOD : TEST_SUB
+END OMNI_TRACER_API;`),
+	}
+	pg, err := NewProcedureGenerator(stub)
+	if err != nil {
+		t.Fatalf("NewProcedureGenerator() returned error: %v", err)
+	}
+
+	if err := pg.DropSubscriberProcedure(context.Background(), "BARNACLE"); err != nil {
+		t.Fatalf("DropSubscriberProcedure() returned error: %v", err)
+	}
+
+	if stub.deployFileCallCount != 1 {
+		t.Fatalf("expected 1 package deploy, got %d", stub.deployFileCallCount)
+	}
+	if strings.Contains(stub.deployedSQL, "TRACE_MESSAGE_BARNACLE") {
+		t.Fatalf("package deployment still contains dropped procedure: %s", stub.deployedSQL)
+	}
+	if !strings.Contains(stub.deployedSQL, "PROCEDURE Enqueue_Event___ (") {
+		t.Fatalf("package deployment should preserve shared helpers: %s", stub.deployedSQL)
+	}
+}
+
+func TestProcedureGenerator_DropSubscriberProcedure_ReturnsNotFoundWhenProcedureMissingFromSource(t *testing.T) {
+	stub := &stubDBRepo{
+		packageSpecSource: splitLines(`CREATE OR REPLACE PACKAGE OMNI_TRACER_API AS
+END OMNI_TRACER_API;`),
+		packageBodySource: splitLines(`CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
+END OMNI_TRACER_API;`),
+	}
+	pg, err := NewProcedureGenerator(stub)
+	if err != nil {
+		t.Fatalf("NewProcedureGenerator() returned error: %v", err)
+	}
+
+	err = pg.DropSubscriberProcedure(context.Background(), "BARNACLE")
+	if !errors.Is(err, domain.ErrProcedureNotFound) {
+		t.Fatalf("DropSubscriberProcedure() error = %v, want ErrProcedureNotFound", err)
+	}
+	if stub.deployFileCallCount != 0 {
+		t.Fatalf("expected no package deploy, got %d", stub.deployFileCallCount)
+	}
+}
+
 func TestNewProcedureGenerator_RejectsNilDatabase(t *testing.T) {
 	pg, err := NewProcedureGenerator(nil)
 	if !errors.Is(err, domain.ErrNilDatabase) {

--- a/internal/service/subscribers/subscriber_service.go
+++ b/internal/service/subscribers/subscriber_service.go
@@ -107,3 +107,14 @@ func (ss *SubscriberService) RegisterSubscriber(ctx context.Context) (*domain.Su
 
 	return subscriber, nil
 }
+
+// DropSubscriberProcedure removes the generated procedure for the subscriber.
+func (ss *SubscriberService) DropSubscriberProcedure(ctx context.Context, funnyName string) error {
+	if ss.procGen == nil {
+		return fmt.Errorf("DropSubscriberProcedure: %w", domain.ErrProcedureGeneration)
+	}
+	if err := ss.procGen.DropSubscriberProcedure(ctx, funnyName); err != nil {
+		return fmt.Errorf("DropSubscriberProcedure: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request delivers Epic 3 Story 3-1, introducing a "Danger Zone" feature within the database settings UI that allows subscribers to delete their generated `TRACE_MESSAGE_<FUNNY_NAME>` procedure.

**Key Changes and Functional Impact:**

1.  **Danger Zone UI Implementation** (`internal/adapter/ui/database_settings.go`, `model.go`, `styles.go`):
    *   A new "Danger Zone" section is added to the database settings screen, visible only when a subscriber has an assigned funny name.
    *   This section is styled with a new `DangerZoneStyle` (red foreground, bold) for visual prominence.
    *   A new keyboard hint "D Nuke Procedure" is added, and pressing 'D' triggers a confirmation modal.
    *   A dedicated `viewDropProcedureConfirmModal()` is implemented, displaying the specific procedure name to be deleted and requiring an explicit 'Y' (confirm) or 'N'/'Esc' (cancel) input.
    *   The `updateDatabaseSettings` function now includes logic to handle the confirmation modal's state and key presses, dispatching `dropSubscriberProcedureMsg` upon confirmation.
    *   General dialogs (for success or error messages) now utilize a new `dialogIsError` state to apply appropriate styling (`OnboardingErrorStyle` for errors, `OnboardingSavedStyle` for success).
    *   The `model.go`'s `View()` method is updated to render the `viewDropProcedureConfirmModal()` as an overlay when active.

2.  **Asynchronous Command Pattern for Deletion** (`internal/adapter/ui/messages.go`, `database_settings.go`):
    *   New message types `dropSubscriberProcedureMsg` and `dropSubscriberProcedureResultMsg` are introduced to facilitate asynchronous handling of the procedure deletion operation, providing user feedback upon completion.

3.  **Subscriber Service Integration** (`internal/service/subscribers/subscriber_service.go`):
    *   A public `DropSubscriberProcedure(ctx context.Context, funnyName string) error` method is added to `SubscriberService`, providing the UI layer with a clean interface to initiate procedure deletion. This method delegates the actual deletion to the `ProcedureGenerator`.

4.  **Refined Procedure Generation Logic** (`internal/service/subscribers/procedure_generator.go`):
    *   The `DropSubscriberProcedure` method's logic has been enhanced. It no longer relies on a `ProcedureExists` database query to determine if a procedure should be dropped.
    *   Instead, it now fetches the package source, attempts to remove the procedure block based on section markers, and then compares the modified source with the original.
    *   **Crucially, if the procedure's section markers are not found in the source (meaning no changes were made), it now explicitly returns `domain.ErrProcedureNotFound`**, rather than silently succeeding. This provides clearer feedback when a procedure is genuinely absent from the package source.

5.  **Comprehensive Testing** (`internal/adapter/ui/database_settings_test.go`, `internal/service/subscribers/procedure_generator_test.go`):
    *   New UI tests (`TestUpdateDatabaseSettings_DropProcedureConfirm_UppercaseYExecutesDropAndShowsSuccess`) validate the end-to-end user flow for confirming and executing a procedure drop, including success message display.
    *   Tests (`TestUpdateDatabaseSettings_DropProcedureConfirm_ShowsErrorWhenProcedureDropUnavailable`) cover scenarios where the deletion service is unavailable, ensuring proper error handling and display.
    *   New `procedure_generator` tests (`TestProcedureGenerator_DropSubscriberProcedure_DropsFromSourceEvenWhenProcedureExistsQueryReturnsFalse`) confirm that the deletion logic correctly removes procedures by parsing the source code, even if a (now removed) `ProcedureExists` query might have returned false.
    *   A test (`TestProcedureGenerator_DropSubscriberProcedure_ReturnsNotFoundWhenProcedureMissingFromSource`) specifically validates the new `ErrProcedureNotFound` behavior when the procedure is not found in the package source.

This feature provides subscribers with a self-service option to manage their generated database procedures, enhancing cleanup capabilities within OmniView.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Danger Zone" in Database Settings to remove a subscriber procedure with a confirmation modal and keyboard shortcut.
  * Confirmation flow now shows success or error messages after the async removal attempt.

* **Style**
  * Introduced an emphasized error/warning style for Danger Zone UI and unified connection border styling.

* **Tests**
  * Added tests covering successful drops and error handling for unavailable drops.

* **Documentation**
  * Added a planning/story document describing the Drop Subscriber Procedure behavior and acceptance criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BasuruK/OmniInspect/pull/94)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->