### PR TITLE
feat: Implement logger adapter with initialization and logging functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _bmad
 .github/skills
 .agents/skills
 .lean-ctx
+omniview.log

--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"OmniView/internal/adapter/logger"
 	"OmniView/internal/adapter/storage/boltdb"
 	"OmniView/internal/adapter/storage/oracle"
 	"OmniView/internal/adapter/ui"
@@ -20,6 +21,17 @@ func main() {
 	// Phase 1: Application Initialization - Pre-TUI setup
 	// ==========================================
 	omniApp := app.New()
+
+	// ── Logger ───────────────────────────────
+	// Must be the first real initialisation step so every subsequent phase
+	// can emit structured log lines to omniview.log.
+	closeLog, err := logger.Init("omniview.log")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialise logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer closeLog()
+	logger.Info("OmniInspect starting", "version", omniApp.GetVersion())
 
 	// Self-update cleanup (remove .old binary leftovers from previous update)
 	updater.CleanupOldBinary()

--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -17,49 +17,46 @@ import (
 )
 
 func main() {
+	omniApp := app.New()
+	if err := run(omniApp); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(omniApp *app.App) error {
 	// ==========================================
 	// Phase 1: Application Initialization - Pre-TUI setup
 	// ==========================================
-	omniApp := app.New()
 
 	// ── Logger ───────────────────────────────
-	// Must be the first real initialisation step so every subsequent phase
-	// can emit structured log lines to omniview.log.
 	closeLog, err := logger.Init("omniview.log")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to initialise logger: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to initialise logger: %w", err)
 	}
 	defer closeLog()
 	logger.Info("OmniInspect starting", "version", omniApp.GetVersion())
 
-	// Self-update cleanup (remove .old binary leftovers from previous update)
 	updater.CleanupOldBinary()
 
-	// Initialize BoltDB (fast, no UI needed)
+	// Initialize BoltDB
 	boltAdapter, err := boltdb.NewBoltAdapter("omniview.bolt")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create BoltDB adapter: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create BoltDB adapter: %w", err)
 	}
 	if err := boltAdapter.Initialize(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to initialize BoltDB: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize BoltDB: %w", err)
 	}
 	defer boltAdapter.Close()
 
 	// ==========================================
-	// Phase 2: Initialize Services (deferred until TUI config is ready)
+	// Phase 2: Initialize Services
 	// ==========================================
 
-	// Event channel: tracer service → TUI
 	eventCh := make(chan *domain.QueueMessage, 100)
-
-	// Updater service for update checking within TUI
 	updaterService := updaterSvc.NewUpdaterService(omniApp.GetVersion())
 
 	// ── Phase 3: Start TUI ───────────────────────
-	// BoltDB is already initialized; TUI handles config loading via onboarding screen
 
 	dbSettingsRepo := boltdb.NewDatabaseSettingsRepository(boltAdapter)
 
@@ -78,17 +75,12 @@ func main() {
 		UpdaterService: updaterService,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create UI model: %w", err)
 	}
 
-	// Request terminal resize to minimum working dimensions (36x130) before TUI starts.
-	// The ANSI sequence CSI 8 ; rows ; cols t is honoured by xterm, Windows Terminal,
-	// macOS Terminal, and most modern emulators.
 	const minRows = 36
 	const minCols = 130
 	if fi, err := os.Stdout.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
-		// Windows CMD/legacy often has no TERM; still emit CSI resize for ConPTY / WT / console.
 		term := os.Getenv("TERM")
 		emit := runtime.GOOS == "windows" ||
 			(term != "" && term != "dumb") ||
@@ -101,11 +93,9 @@ func main() {
 	p := ui.NewProgram(model)
 	if _, err := p.Run(); err != nil {
 		tracer.StopWebhookDispatcher()
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("TUI error: %w", err)
 	}
 
-	// Ensure all tracer goroutines are stopped before exiting
 	tracer.StopWebhookDispatcher()
-
+	return nil
 }

--- a/internal/adapter/logger/logger.go
+++ b/internal/adapter/logger/logger.go
@@ -34,17 +34,18 @@ import (
 // ─────────────────────────
 
 // handle holds the active slog.Handler.
-// atomic.Pointer keeps swaps safe when Init() is called on the main
-// goroutine while other goroutines may already be logging.
-var handle atomic.Pointer[slog.Handler]
+// atomic.Value allows storage of the interface type directly (vs atomic.Pointer
+// which would require *slog.Handler). Swaps are safe when Init() is called on the
+// main goroutine while other goroutines may already be logging.
+var handle atomic.Value
 
 func init() {
 	// Bootstrap fallback: stderr until Init() configures the real file.
-	h := slog.Handler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		AddSource: true,
 		Level:     slog.LevelDebug,
-	}))
-	handle.Store(&h)
+	})
+	handle.Store(h)
 }
 
 // ─────────────────────────
@@ -57,16 +58,16 @@ func init() {
 //
 // Call once — only from cmd/omniview/main.go (composition root).
 func Init(logPath string) (func(), error) {
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("logger.Init: open %q: %w", logPath, err)
 	}
 
-	h := slog.Handler(slog.NewTextHandler(f, &slog.HandlerOptions{
+	h := slog.NewTextHandler(f, &slog.HandlerOptions{
 		AddSource: true,
 		Level:     slog.LevelDebug,
-	}))
-	handle.Store(&h)
+	})
+	handle.Store(h)
 
 	return func() { _ = f.Close() }, nil
 }
@@ -80,12 +81,13 @@ func Init(logPath string) (func(), error) {
 // log entry reflects the package that called Debug/Info/Warn/Error.
 //
 // Stack depth for runtime.Callers:
-//   0 = runtime.Callers itself
-//   1 = emit
-//   2 = Debug / Info / Warn / Error (exported wrapper)
-//   3 = actual call site  ← we want this
+//
+//	0 = runtime.Callers itself
+//	1 = emit
+//	2 = Debug / Info / Warn / Error (exported wrapper)
+//	3 = actual call site  ← we want this
 func emit(level slog.Level, msg string, args ...any) {
-	h := *handle.Load()
+	h := handle.Load().(slog.Handler)
 	ctx := context.Background()
 	if !h.Enabled(ctx, level) {
 		return
@@ -121,5 +123,5 @@ func Error(msg string, args ...any) { emit(slog.LevelError, msg, args...) }
 //	log := logger.With("subscriber", name)
 //	log.Info("dequeue started")
 func With(args ...any) *slog.Logger {
-	return slog.New(*handle.Load()).With(args...)
+	return slog.New(handle.Load().(slog.Handler)).With(args...)
 }

--- a/internal/adapter/logger/logger.go
+++ b/internal/adapter/logger/logger.go
@@ -1,0 +1,125 @@
+package logger
+
+// ==========================================
+// Application Logger Adapter
+// ==========================================
+// Backed by the stdlib log/slog package (Go 1.21+).
+//
+// Call Init() once from the composition root (cmd/omniview/main.go).
+// Every package in the codebase can then call the package-level
+// functions Debug / Info / Warn / Error directly — no parameters,
+// no injected dependencies. The calling file, function name, and
+// line number are captured automatically via runtime.Callers at the
+// correct stack depth, so each log line knows exactly where it came from.
+//
+// Log format (text, human-readable):
+//
+//	time=2026-05-13T14:00:00Z level=INFO source=oracle_adapter.go:112 msg="dequeue started" subscriber=OMNI_SUB
+//
+// Before Init() is called the logger falls back to stderr, so early
+// startup errors are never silently lost.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// ─────────────────────────
+// Internal state
+// ─────────────────────────
+
+// handle holds the active slog.Handler.
+// atomic.Pointer keeps swaps safe when Init() is called on the main
+// goroutine while other goroutines may already be logging.
+var handle atomic.Pointer[slog.Handler]
+
+func init() {
+	// Bootstrap fallback: stderr until Init() configures the real file.
+	h := slog.Handler(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+	handle.Store(&h)
+}
+
+// ─────────────────────────
+// Initializer
+// ─────────────────────────
+
+// Init opens (or creates/appends to) logPath and installs a file-backed
+// text handler as the active logger. Returns a cleanup func that must
+// be deferred in main() to flush and close the log file cleanly.
+//
+// Call once — only from cmd/omniview/main.go (composition root).
+func Init(logPath string) (func(), error) {
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("logger.Init: open %q: %w", logPath, err)
+	}
+
+	h := slog.Handler(slog.NewTextHandler(f, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+	handle.Store(&h)
+
+	return func() { _ = f.Close() }, nil
+}
+
+// ─────────────────────────
+// Internal dispatch
+// ─────────────────────────
+
+// emit creates a slog.Record with the program counter of the actual
+// call site (not of this wrapper), so the source file/line in each
+// log entry reflects the package that called Debug/Info/Warn/Error.
+//
+// Stack depth for runtime.Callers:
+//   0 = runtime.Callers itself
+//   1 = emit
+//   2 = Debug / Info / Warn / Error (exported wrapper)
+//   3 = actual call site  ← we want this
+func emit(level slog.Level, msg string, args ...any) {
+	h := *handle.Load()
+	ctx := context.Background()
+	if !h.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:])
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.Add(args...)
+	_ = h.Handle(ctx, r)
+}
+
+// ─────────────────────────
+// Public API
+// ─────────────────────────
+
+// Debug logs a message at DEBUG level.
+// Accepts alternating key-value pairs or slog.Attr values as args.
+func Debug(msg string, args ...any) { emit(slog.LevelDebug, msg, args...) }
+
+// Info logs a message at INFO level.
+func Info(msg string, args ...any) { emit(slog.LevelInfo, msg, args...) }
+
+// Warn logs a message at WARN level.
+func Warn(msg string, args ...any) { emit(slog.LevelWarn, msg, args...) }
+
+// Error logs a message at ERROR level.
+func Error(msg string, args ...any) { emit(slog.LevelError, msg, args...) }
+
+// With returns a *slog.Logger pre-loaded with the given attributes.
+// Useful for long-lived components that want to attach a fixed context
+// to every log call without repeating keys:
+//
+//	log := logger.With("subscriber", name)
+//	log.Info("dequeue started")
+func With(args ...any) *slog.Logger {
+	return slog.New(*handle.Load()).With(args...)
+}

--- a/scripts/debug.sqlnb
+++ b/scripts/debug.sqlnb
@@ -24,7 +24,7 @@ cells:
                       WHEN 2 THEN v_level := 'ERROR';
                       WHEN 3 THEN v_level := 'DEBUG';
                   END CASE;
-                  OMNI_TRACER_API.TRACE_MESSAGE_PEBBLES('HI Trace Message No ' || i, v_level);
+                  OMNI_TRACER_API.TRACE_MESSAGE('HI Trace Message No ' || i, v_level);
               END;
           END LOOP;
           --COMMIT;  -- Important!


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a robust, structured logging system to OmniInspect, leveraging Go's standard library `log/slog` package (Go 1.21+). This implementation provides comprehensive, diagnostic-quality logging without introducing any external dependencies.

### Key Changes and Technical Context:

1.  **New Structured Logger Adapter (`internal/adapter/logger/logger.go`)**:
    *   **Standard Library Foundation**: Built entirely on `log/slog`, ensuring a lightweight solution with no third-party dependencies, which simplifies maintenance and reduces supply chain risk.
    *   **Thread-Safe Handler Management**: Employs `atomic.Pointer[slog.Handler]` to safely manage the active logger handler. This guarantees that the handler can be updated (e.g., during `Init()`) without race conditions, even if other goroutines are concurrently attempting to log.
    *   **Accurate Source Attribution**: The `emit` function uses `runtime.Callers(3, pcs[:])` to precisely capture the file and line number of the *actual call site* (i.e., where `Debug`, `Info`, `Warn`, or `Error` was invoked), rather than the internal wrapper function. This significantly improves the traceability of log messages.
    *   **Persistent File Logging**: The `Init` function opens the log file (`omniview.log`) with `os.O_APPEND`, ensuring that log data is preserved across application restarts rather than being overwritten. This is crucial for historical analysis and debugging long-running issues.
    *   **Early Startup Fallback**: An `init()` function configures a default `slog.NewTextHandler` that writes to `os.Stderr`. This critical fallback ensures that any errors or messages occurring *before* the main `logger.Init()` call are not silently lost, providing immediate feedback during application bootstrap.
    *   **Contextual Logging**: The `With()` function allows creating derived logger instances with predefined key-value pairs. This enables components to automatically include specific context (e.g., a subscriber ID or module name) in all their log messages without repetition, enhancing log readability and filtering capabilities.

2.  **Early Integration in Main Entry Point (`cmd/omniview/main.go`)**:
    *   **First-Class Initialization**: The logger is now the *first real initialization step* in `main()`. This guarantees that all subsequent application components and startup phases have a fully configured logging mechanism available from the outset.
    *   **Robust Initialization Error Handling**: If `logger.Init()` fails (e.g., due to inability to open the log file), the application now explicitly prints the error to `os.Stderr` and exits with status code 1. This prevents the application from starting in a potentially unlogged or misconfigured state.
    *   **Guaranteed Cleanup**: A `defer closeLog()` call ensures that the log file is properly flushed and closed when the `main` function exits, preventing data loss from buffered writes.
    *   **Application Startup Logging**: An `logger.Info("OmniInspect starting", "version", omniApp.GetVersion())` message is emitted at startup, providing immediate confirmation of the application's launch and its version within the log file, which is invaluable for operational monitoring and debugging.

This implementation establishes a foundational logging infrastructure that is both powerful and simple to use, significantly enhancing the application's observability and diagnostic capabilities.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now generates log files for improved diagnostics.
  * Startup messages now include application version information.

* **Chores**
  * Updated ignore patterns for project artifacts and log files.
  * Updated debug script tracing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BasuruK/OmniInspect/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->