### PR TITLE
Fix DropSubscriberProcedure error handling

### DIFF
--- a/internal/service/subscribers/procedure_generator.go
+++ b/internal/service/subscribers/procedure_generator.go
@@ -233,6 +233,8 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
 	}
 
+	originalSpec, originalBody := packageSpec, packageBody
+
 	packageSpec, err = removeProcedureDeclaration(packageSpec, procedureName)
 	if err != nil {
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
@@ -240,6 +242,10 @@ func (pg *ProcedureGenerator) DropSubscriberProcedure(ctx context.Context, funny
 	packageBody, err = removeProcedureBody(packageBody, procedureName)
 	if err != nil {
 		return fmt.Errorf("DropSubscriberProcedure: %w", err)
+	}
+
+	if packageSpec == originalSpec && packageBody == originalBody {
+		return fmt.Errorf("DropSubscriberProcedure: %w", domain.ErrProcedureNotFound)
 	}
 
 	if err := pg.db.DeployFile(ctx, renderPackageDeploymentSQL(packageSpec, packageBody)); err != nil {

--- a/internal/service/subscribers/procedure_generator_test.go
+++ b/internal/service/subscribers/procedure_generator_test.go
@@ -724,8 +724,10 @@ func splitLines(input string) []string {
 func TestProcedureGenerator_DropSubscriberProcedure_ReturnsErrNotFound(t *testing.T) {
 	stub := &stubDBRepo{
 		procedureExists: map[string]bool{buildProcedureName("BARNACLE"): true},
-		packageSpecSource: splitLines("CREATE OR REPLACE PACKAGE OMNI_TRACER_API AS\nEND OMNI_TRACER_API;"),
-		packageBodySource: splitLines("CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS\nEND OMNI_TRACER_API;"),
+		packageSpecSource: splitLines(`CREATE OR REPLACE PACKAGE OMNI_TRACER_API AS
+END OMNI_TRACER_API;`),
+		packageBodySource: splitLines(`CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
+END OMNI_TRACER_API;`),
 	}
 	pg, err := NewProcedureGenerator(stub)
 	if err != nil {

--- a/internal/service/subscribers/procedure_generator_test.go
+++ b/internal/service/subscribers/procedure_generator_test.go
@@ -720,3 +720,20 @@ func splitLines(input string) []string {
 	}
 	return lines
 }
+
+func TestProcedureGenerator_DropSubscriberProcedure_ReturnsErrNotFound(t *testing.T) {
+	stub := &stubDBRepo{
+		procedureExists: map[string]bool{buildProcedureName("BARNACLE"): true},
+		packageSpecSource: splitLines("CREATE OR REPLACE PACKAGE OMNI_TRACER_API AS\nEND OMNI_TRACER_API;"),
+		packageBodySource: splitLines("CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS\nEND OMNI_TRACER_API;"),
+	}
+	pg, err := NewProcedureGenerator(stub)
+	if err != nil {
+		t.Fatalf("NewProcedureGenerator() returned error: %v", err)
+	}
+
+	err = pg.DropSubscriberProcedure(context.Background(), "BARNACLE")
+	if !errors.Is(err, domain.ErrProcedureNotFound) {
+		t.Errorf("expected ErrProcedureNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refines the error handling within the `DropSubscriberProcedure` function in `internal/service/subscribers/procedure_generator.go`.

**Key Changes and Functional Impact:**

1.  **Explicit Procedure Not Found Detection:**
    *   The `DropSubscriberProcedure` function now captures the `packageSpec` and `packageBody` content *before* attempting to remove the specified procedure.
    *   After calling `removeProcedureDeclaration` and `removeProcedureBody`, it compares the modified `packageSpec` and `packageBody` with their original states.
    *   If both the package specification and package body remain entirely unchanged after the removal attempts, it explicitly indicates that the procedure was not found within the package source.

2.  **Improved Error Reporting:**
    *   When a procedure is not found (i.e., no changes were made to the package content), the function now returns `domain.ErrProcedureNotFound`. This provides a precise and actionable error to the caller, distinguishing it from other potential errors during the drop operation.

3.  **Prevention of Unnecessary Deployments:**
    *   By explicitly returning `ErrProcedureNotFound` when no changes occur, the system avoids proceeding to `pg.db.DeployFile` with an identical package configuration. This prevents unnecessary database operations and potential deployment of unchanged artifacts, improving efficiency and clarity.

4.  **Enhanced Test Coverage:**
    *   A new test case, `TestProcedureGenerator_DropSubscriberProcedure_ReturnsErrNotFound`, has been added to `internal/service/subscribers/procedure_generator_test.go`. This test specifically verifies that when `DropSubscriberProcedure` is called for a procedure not present in the initial package source, it correctly returns `domain.ErrProcedureNotFound`. The test uses a stub database repository with empty package definitions to simulate this scenario.

This change directly addresses "Finding 3" by ensuring that `DropSubscriberProcedure` accurately reports when a procedure to be dropped is not found in the package source, rather than silently failing or deploying an unchanged package.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection when attempting to remove subscriber procedures, preventing unsuccessful removal operations from being deployed without reporting an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BasuruK/OmniInspect/pull/97)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->