### PR TITLE
sprint course correction: parking package deletion

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -82,12 +82,12 @@ development_status:
     notes: "DangerZoneStyle, danger zone UI, D key handler, confirmation modal, async command wiring. make test and make build passing."
 
   3-2-drop-entire-package:
-    status: "ready-for-dev"
-    title: "Drop Entire Package (Danger Zone)"
+    status: "cancelled"
+    title: "Drop Entire Package (Danger Zone) — PARKED"
     epic: "Epic 3: Danger Zone Implementation"
     owner: "dev-agent"
-    last_updated: "2026-04-28"
-    notes: "Add danger zone option to drop entire OMNI_TRACER_API package"
+    last_updated: "2026-05-17"
+    notes: "PARKED: Security risk — package drop affects all subscribers, not just the requestor. FR-4 removed from plan. Feature may be revisited as admin-only operation with proper access controls."
 
   3-3-safe-subscriber-unregistration:
     status: "ready-for-dev"
@@ -103,9 +103,8 @@ development_status:
 metrics:
   total_stories: 9
   completed: 6
-  in_progress: 0
-  ready_for_dev: 3
-  blocked: 0
+  ready_for_dev: 2
+  cancelled: 1
   completion_percentage: 67
 
 # ==========================================
@@ -131,6 +130,7 @@ epic_summary:
     stories_total: 3
     stories_completed: 1
     stories_in_progress: 0
+    stories_cancelled: 1
     status: "in-progress"
 
 # ==========================================

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -102,10 +102,10 @@ development_status:
 # ==========================================
 metrics:
   total_stories: 9
-  completed: 6
-  ready_for_dev: 2
+  completed: 7
+  ready_for_dev: 1
   cancelled: 1
-  completion_percentage: 67
+  completion_percentage: 78
 
 # ==========================================
 # EPIC SUMMARY
@@ -121,9 +121,9 @@ epic_summary:
   epic-2:
     title: "Epic 2: TUI Procedure Name Display"
     stories_total: 1
-    stories_completed: 0
+    stories_completed: 1
     stories_in_progress: 0
-    status: "pending"
+    status: "done"
 
   epic-3:
     title: "Epic 3: Danger Zone Implementation"

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -48,7 +48,7 @@ _This document builds collaboratively through step-by-step discovery. Sections a
 | Creation | Idempotent - check if exists, only create if missing |
 | SQL injection | Strict format validation before DDL generation |
 | Package invalidation | Accepted risk - app redeploys on restart |
-| Danger zone options | Per-subscriber method deletion OR drop entire OMNI_TRACER_API package |
+| Danger zone options | Per-subscriber method deletion only (FR-4 / Story 3-2 PARKED — package drop removed from scope) |
 | Auto-redeploy | Already implemented - if package missing, OmniView redeploys |
 | Permissions | Any database user can call generated procedures |
 | Scalability | N subscribers supported, no hard limit |

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -76,7 +76,7 @@ IFS Cloud executes trace calls under IFS app user identity, NOT the debugging Om
 - FR-1: Generate unique `TRACE_MESSAGE_<subscriber_id>()` procedure per subscriber on registration
 - FR-2: Idempotent creation - check if procedure exists before creating
 - FR-3: **Modify Settings UI** - Add danger zone option to drop subscriber-specific procedure
-- FR-4: **Modify Settings UI** - Add danger zone option to drop entire OMNI_TRACER_API package
+- (FR-4 REMOVED: Package-drop poses unacceptable risk — accidental deletion affects all subscribers)
 - FR-5: Auto-redeploy package on startup if missing
 - FR-6: Strict name format validation (`^[A-Za-z_]+$`) to prevent SQL injection
 - FR-7: Display the subscriber's method name in TUI - Show the user the exact procedure they must call in their PL/SQL code to receive subscriber-isolated messages (e.g., `OMNI_TRACER_API.TRACE_MESSAGE_SUB_0CC283A4...`)
@@ -395,7 +395,10 @@ END TRACE_MESSAGE_BARNACLE;
 Danger zone section in Settings screen:
 - Visual distinction (red/warning styling)
 - Confirmation required before destructive actions
-- Two options: Drop subscriber procedure OR Drop entire package
+- ONE option: Drop subscriber-specific procedure only
+
+NOTE: Drop entire OMNI_TRACER_API package (FR-4) has been PARKED due to risk concerns.
+If needed in the future, it should be implemented as an admin-only operation with separate access controls.
 
 ### Enforcement Guidelines
 
@@ -564,7 +567,7 @@ Service Layer
 | **FR-1, FR-2, FR-6**: Generate `TRACE_MESSAGE_<funny>` procedure | `internal/core/domain/funny_names.go` | **NEW** - Curated name list + validation |
 | | `internal/service/subscribers/subscriber_service.go` | **MODIFY** - Add `EnsureSubscriberProcedure()` |
 | | `internal/adapter/storage/oracle/oracle_adapter.go` | **MODIFY** - Add DDL execution for procedure creation |
-| **FR-3, FR-4**: Danger zone options | `internal/adapter/ui/database_settings.go` | **MODIFY** - Add "Drop my procedure" + "Drop all procedures" |
+| **FR-3**: Danger zone options | `internal/adapter/ui/database_settings.go` | **MODIFY** - Add "Drop my procedure" |
 | **FR-5**: Auto-redeploy on startup | `internal/adapter/storage/oracle/oracle_adapter.go` | **VERIFY** - Check existing redeploy logic |
 | **FR-7**: Display method name in TUI | `internal/adapter/ui/main_screen.go` | **MODIFY** - Show `OMNI_TRACER_API.TRACE_MESSAGE_<NAME>()` in header |
 
@@ -628,7 +631,7 @@ IFS Cloud → OMNI_TRACER_API.TRACE_MESSAGE_<NAME>('msg')
 | Requirement | Status | Evidence |
 |-------------|--------|----------|
 | FR-1, FR-2, FR-6: Generate procedure | ✅ | `ExecuteStatement()` at runtime DDL |
-| FR-3, FR-4: Danger zone options | ✅ | `database_settings.go` modification |
+| FR-3: Danger zone options (FR-4 PARKED) | ✅ | `database_settings.go` modification |
 | FR-5: Auto-redeploy | ✅ | Existing `DeployAndCheck()` |
 | FR-7: Display method name | ✅ | `main_screen.go` header area |
 

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -29,8 +29,6 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 **FR-3:** Modify Settings UI - Add danger zone option to drop subscriber-specific procedure
 
-**FR-4:** Modify Settings UI - Add danger zone option to drop entire OMNI_TRACER_API package
-
 **FR-5:** Auto-redeploy package on startup if missing
 
 **FR-6:** Strict name format validation (`^[A-Za-z_]+$`) to prevent SQL injection
@@ -76,7 +74,6 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 | FR-1 | Generate TRACE_MESSAGE_<FUNNY_NAME>() procedure per subscriber | Epic 1 |
 | FR-2 | Idempotent creation | Epic 1 |
 | FR-3 | Drop subscriber-specific procedure | Epic 3 |
-| FR-4 | Drop entire OMNI_TRACER_API package | Epic 3 |
 | FR-5 | Auto-redeploy on startup | Epic 1 |
 | FR-6 | Strict name format validation | Epic 1 |
 | FR-7 | Display procedure name in TUI | Epic 2 |
@@ -99,9 +96,9 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 
 ### Epic 3: Danger Zone Implementation
 
-**User Outcome:** Subscribers can clean up their procedures or the entire package when needed, and the application safely unregisters from Oracle AQ on shutdown.
+**User Outcome:** Subscribers can clean up their own procedures and safely unregister from Oracle AQ on shutdown.
 
-**FRs Covered:** FR-3, FR-4, FR-9
+**FRs Covered:** FR-3, FR-9
 
 **FR-9:** Safe subscriber unregistration from Oracle AQ on application shutdown
 
@@ -260,26 +257,6 @@ So that I can clean up when I no longer need tracing.
 **Given** the procedure is deleted
 **When** OmniView restarts
 **Then** if the subscriber is still registered, the procedure is regenerated
-
----
-
-### Story 3.2: Drop Entire Package (Danger Zone)
-
-As a subscriber,
-I want to drop the entire OMNI_TRACER_API package,
-So that I can remove all generated procedures at once.
-
-**Acceptance Criteria:**
-
-**Given** the subscriber is on the Settings screen
-**When** they select "Drop All Procedures"
-**Then** a confirmation dialog appears with strong warning
-**And** if confirmed, the entire OMNI_TRACER_API package is dropped from the database
-
-**Given** the package is dropped
-**When** OmniView restarts
-**Then** it redeploys the base package with subscriber-routed `Enqueue_Event___()` support
-**And** it regenerates all subscriber procedures
 
 ---
 

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -62,8 +62,7 @@ This document provides the complete epic and story breakdown for OmniInspect, de
 **UX-DR2:** Add danger zone section in Settings screen with:
 - Clear visual distinction (red/warning styling)
 - Confirmation required before destructive actions
-- Option to drop subscriber-specific procedure
-- Option to drop entire OMNI_TRACER_API package
+- Option to drop subscriber-specific procedure (package-drop option removed — FR-4 / Story 3-2 PARKED)
 
 **UX-DR3:** Settings screen keyboard shortcut (S key) already implemented - verify danger zone integration works correctly
 

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-05-17.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-05-17.md
@@ -1,0 +1,266 @@
+---
+stepsCompleted: [1, 2, 3, 4, 5, 6]
+status: 'approved'
+workflowType: 'correct-course'
+trigger: 'User concern about security risk of FR-4 (drop entire OMNI_TRACER_API package) feature'
+date: '2026-05-17'
+project_name: OmniInspect
+user_name: Basuruk
+---
+
+# Sprint Change Proposal — Park FR-4 / Story 3-2
+
+## 1. Issue Summary
+
+**Problem Statement**: The "Drop Entire Package" feature (FR-4 / Story 3-2) poses unacceptable security and operational risk. If one subscriber drops the `OMNI_TRACER_API` package, ALL subscribers lose their procedures immediately — affecting active users who haven't triggered the action.
+
+**Context**:
+- Epic 1 completed — per-subscriber procedure generation working ✅
+- Story 3-1 completed — drop subscriber-specific procedure ✅
+- Story 3-2 (drop entire package) was planned but never implemented
+- User raised concern: giving non-admin users the ability to drop the entire package is dangerous
+
+**Evidence**: User's direct observation during Epic 3 planning review — "I have a concern if we should give that feature. I feel like its a security risk giving access to such features to users."
+
+---
+
+## 2. Impact Analysis
+
+### Epic Impact
+
+| Epic | Status | Change |
+|------|--------|--------|
+| Epic 1 | ✅ COMPLETE | None — fully implemented |
+| Epic 2 | ✅ COMPLETE | None — Story 2-1 done |
+| Epic 3 | In Progress | Story 3-2 REMOVED; Stories 3-1 (done) and 3-3 (pending) remain viable |
+
+**Epic 3 remains viable** — the primary danger zone use case (delete my procedure) is satisfied by Story 3-1. FR-9 (safe unregistration on shutdown) is independent and unaffected.
+
+### Story Impact
+
+| Story | Status | Change |
+|-------|--------|--------|
+| 3-1 | ✅ DONE | Unaffected — drop subscriber-specific procedure |
+| 3-2 | 🛑 REMOVED | Never implemented — removed from plan |
+| 3-3 | Pending | Unaffected — safe unregistration on shutdown |
+
+### Artifact Conflicts
+
+| Artifact | Conflict | Resolution |
+|----------|---------|------------|
+| `planning-artifacts/epics.md` | FR-4 listed, Story 3-2 defined | Remove FR-4, remove Story 3-2 section |
+| `planning-artifacts/architecture.md` | Pattern 4 describes two danger zone options | Update to single option (drop my procedure); note FR-4 parked |
+| `implementation-artifacts/sprint-status.yaml` | Story 3-2 status `ready-for-dev` | Mark as `cancelled` |
+| `implementation-artifacts/stories/3-2-drop-entire-package.md` | File exists but story never implemented | Mark as deprecated |
+
+### Technical Impact
+
+**None** — Story 3-2 was never implemented. No code removal required.
+
+---
+
+## 3. Recommended Approach
+
+**Selected Path**: Direct Adjustment — scope reduction by removing one feature from the plan.
+
+**Rationale**:
+- Story 3-2 was never built — no code to remove
+- Epic 3 remains viable with Stories 3-1 and 3-3
+- FR-3 (drop my procedure) satisfies the primary user need
+- Risk of accidental mass deletion is eliminated
+- Low effort — artifact updates only
+
+**Alternatives Considered**:
+- Option 2 (Rollback): N/A — Story 3-2 was never implemented
+- Option 3 (MVP Review): Overkill — removing one feature doesn't require fundamental replan
+
+**Effort**: Low (artifact updates only, ~1 hour)
+**Risk**: Low (no code removal, just documentation)
+**Timeline Impact**: None — Story 3-2 was not on the critical path
+
+---
+
+## 4. Detailed Change Proposals
+
+### Change 4.1: `planning-artifacts/epics.md`
+
+**Requirements Inventory — remove FR-4:**
+```
+REMOVE:
+**FR-4:** Modify Settings UI - Add danger zone option to drop entire OMNI_TRACER_API package
+```
+
+**FR Coverage Map — remove FR-4 row:**
+```
+REMOVE row:
+| FR-4 | Drop entire OMNI_TRACER_API package | Epic 3 |
+```
+
+**Epic 3 description — update user outcome and FR coverage:**
+```
+OLD:
+### Epic 3: Danger Zone Implementation
+
+**User Outcome:** Subscribers can clean up their procedures or the entire package when needed, and the application safely unregisters from Oracle AQ on shutdown.
+
+**FRs Covered:** FR-3, FR-4, FR-9
+
+NEW:
+### Epic 3: Danger Zone Implementation
+
+**User Outcome:** Subscribers can clean up their own procedures and safely unregister from Oracle AQ on shutdown.
+
+**FRs Covered:** FR-3, FR-9
+```
+
+**Story 3.2 — remove entire section:**
+```
+REMOVE:
+### Story 3.2: Drop Entire Package (Danger Zone)
+
+As a subscriber,
+I want to drop the entire OMNI_TRACER_API package,
+So that I can remove all generated procedures at once.
+
+[Full acceptance criteria and technical details — remove entirely]
+```
+
+---
+
+### Change 4.2: `planning-artifacts/architecture.md`
+
+**Requirements Overview — update FR-3, remove FR-4:**
+```
+OLD:
+- FR-3: **Modify Settings UI** - Add danger zone option to drop subscriber-specific procedure
+- FR-4: **Modify Settings UI** - Add danger zone option to drop entire OMNI_TRACER_API package
+
+NEW:
+- FR-3: **Modify Settings UI** - Add danger zone option to drop subscriber-specific procedure
+- (FR-4 REMOVED: Package-drop poses unacceptable risk — accidental deletion affects all subscribers)
+```
+
+**Pattern 4: Settings UI Danger Zone — update description:**
+```
+OLD:
+Danger zone section in Settings screen:
+- Visual distinction (red/warning styling)
+- Confirmation required before destructive actions
+- Two options: Drop subscriber procedure OR Drop entire package
+
+NEW:
+Danger zone section in Settings screen:
+- Visual distinction (red/warning styling)
+- Confirmation required before destructive actions
+- ONE option: Drop subscriber-specific procedure only
+
+NOTE: Drop entire OMNI_TRACER_API package (FR-4) has been PARKED due to risk concerns.
+If needed in the future, it should be implemented as an admin-only operation with separate access controls.
+```
+
+**Requirements to Structure Mapping — remove FR-4:**
+```
+OLD:
+| FR-3, FR-4: Danger zone options | `internal/adapter/ui/database_settings.go` | **MODIFY** - Add "Drop my procedure" + "Drop all procedures" |
+
+NEW:
+| FR-3: Danger zone options | `internal/adapter/ui/database_settings.go` | **MODIFY** - Add "Drop my procedure" |
+```
+
+---
+
+### Change 4.3: `implementation-artifacts/sprint-status.yaml`
+
+**Story 3-2 status change:**
+```
+OLD:
+  3-2-drop-entire-package:
+    status: "ready-for-dev"
+    title: "Drop Entire Package (Danger Zone)"
+    epic: "Epic 3: Danger Zone Implementation"
+    owner: "dev-agent"
+    last_updated: "2026-04-28"
+    notes: "Add danger zone option to drop entire OMNI_TRACER_API package"
+
+NEW:
+  3-2-drop-entire-package:
+    status: "cancelled"
+    title: "Drop Entire Package (Danger Zone) — PARKED"
+    epic: "Epic 3: Danger Zone Implementation"
+    owner: "dev-agent"
+    last_updated: "2026-05-17"
+    notes: "PARKED: Security risk — package drop affects all subscribers, not just the requestor. FR-4 removed from plan. Feature may be revisited as admin-only operation with proper access controls."
+```
+
+**Metrics update:**
+```
+OLD:
+  total_stories: 9
+  completed: 6
+  ready_for_dev: 3
+
+NEW:
+  total_stories: 9
+  completed: 6
+  ready_for_dev: 2
+  cancelled: 1
+```
+
+**Epic 3 summary update:**
+```
+OLD:
+  epic-3:
+    title: "Epic 3: Danger Zone Implementation"
+    stories_total: 3
+    stories_completed: 1
+    stories_in_progress: 0
+    status: "in-progress"
+
+NEW:
+  epic-3:
+    title: "Epic 3: Danger Zone Implementation"
+    stories_total: 3
+    stories_completed: 1
+    stories_in_progress: 0
+    stories_cancelled: 1
+    status: "in-progress"
+```
+
+---
+
+## 5. Implementation Handoff
+
+**Change Scope**: Minor — artifact updates only, no code changes
+
+**Handoff**: Developer agent (bmad-dev-story) can apply directly
+
+**Artifacts to Modify**:
+1. `_bmad-output/planning-artifacts/epics.md`
+2. `_bmad-output/planning-artifacts/architecture.md`
+3. `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+**Files to Deprecate**:
+- `stories/3-2-drop-entire-package.md` — rename to `stories/3-2-drop-entire-package.md.deprecated` or add note
+
+**Success Criteria**:
+- epics.md no longer references FR-4 or Story 3.2
+- architecture.md Pattern 4 reflects single danger zone option
+- sprint-status.yaml shows Story 3-2 as `cancelled`
+- Epic 3 remains viable with Stories 3-1 (done) and 3-3 (pending)
+
+---
+
+## 6. Resolution
+
+**Approved by**: Basuruk
+**Date**: 2026-05-17
+**Approach**: Option 1 — Direct Adjustment (scope reduction)
+
+**Next Steps**:
+1. Apply artifact changes as detailed above
+2. Epic 3 continues with remaining stories (3-1 done, 3-3 pending)
+3. FR-4 may be revisited in future as admin-only operation with proper access controls
+
+---
+
+*Correct Course workflow complete — Basuruk!*


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates project planning and sprint status artifacts to reflect the cancellation and parking of the "Drop Entire Package (Danger Zone)" feature (Functional Requirement FR-4 / Story 3-2).

The decision to remove this feature was made due to significant security and operational risks. Allowing any subscriber to drop the entire `OMNI_TRACER_API` package could inadvertently affect all other active subscribers, leading to widespread disruption.

Key changes include:
*   **Cancellation of Story 3-2**: The story "Drop Entire Package (Danger Zone)" has been marked as "cancelled" and "PARKED" in the sprint status, with updated notes explaining the security concerns.
*   **Removal of FR-4**: Functional Requirement FR-4, which described the option to drop the entire package, has been removed from the architecture and epics documentation.
*   **Updated UI Scope**: The Settings UI's "Danger Zone" will now only offer the option to drop a *subscriber-specific procedure* (FR-3), eliminating the option to drop the entire package.
*   **Planning Artifact Updates**: `epics.md` and `architecture.md` have been revised to remove all references to FR-4 and Story 3-2, including user outcomes, FR coverage, and detailed story descriptions.
*   **Metrics Adjustment**: Sprint metrics have been updated to reflect one cancelled story.

This change ensures that the application's design prioritizes system stability and prevents accidental mass deletion, while still allowing subscribers to manage their individual procedures. The feature may be revisited in the future as an admin-only operation with appropriate access controls. No code changes were required as the feature was never implemented.
<!-- kody-pr-summary:end -->