### PR TITLE
Implement safe unregistration of subscribers on shutdown

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -2,7 +2,8 @@ runtimes:
     - java@17.0.10
     - python@3.11.11
 tools:
+    - lizard@1.17.31
     - opengrep@1.21.0
     - pmd@6.55.0
-    - lizard@1.17.31
+    - pylint@4.0.5
     - trivy@0.70.0

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -2,8 +2,7 @@ runtimes:
     - java@17.0.10
     - python@3.11.11
 tools:
-    - lizard@1.17.31
     - opengrep@1.21.0
     - pmd@6.55.0
-    - pylint@4.0.5
+    - lizard@1.17.31
     - trivy@0.70.0

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -102,10 +102,10 @@ development_status:
 # ==========================================
 metrics:
   total_stories: 9
-  completed: 7
-  ready_for_dev: 1
+  completed: 8
+  ready_for_dev: 0
   cancelled: 1
-  completion_percentage: 78
+  completion_percentage: 89
 
 # ==========================================
 # EPIC SUMMARY
@@ -128,10 +128,10 @@ epic_summary:
   epic-3:
     title: "Epic 3: Danger Zone Implementation"
     stories_total: 3
-    stories_completed: 1
+    stories_completed: 2
     stories_in_progress: 0
     stories_cancelled: 1
-    status: "in-progress"
+    status: "done"
 
 # ==========================================
 # NEXT ACTIONS

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -90,12 +90,12 @@ development_status:
     notes: "PARKED: Security risk — package drop affects all subscribers, not just the requestor. FR-4 removed from plan. Feature may be revisited as admin-only operation with proper access controls."
 
   3-3-safe-subscriber-unregistration:
-    status: "ready-for-dev"
+    status: "done"
     title: "Safe Subscriber Unregistration on Shutdown"
     epic: "Epic 3: Danger Zone Implementation"
     owner: "dev-agent"
-    last_updated: "2026-05-09"
-    notes: "Unregister subscriber from Oracle AQ on graceful shutdown via DBMS_AQADM.REMOVE_SUBSCRIBER. Uncomment and implement Unregister_Subscriber in OMNI_TRACER_API. Handle timeout for unreachable Oracle."
+    last_updated: "2026-05-18"
+    notes: "Unregister_Subscriber PL/SQL procedure added to OMNI_TRACER_API. UnregisterSubscriber port + Oracle adapter implemented. activeSubscriber stored in TracerService, called in CancelConnectionListener with 5s timeout. 3 new unit tests. make test and make build passing."
 
 # ==========================================
 # SPRINT METRICS

--- a/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
+++ b/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
@@ -1,0 +1,300 @@
+---
+story_key: "3-3-safe-subscriber-unregistration"
+epic_key: "epic-3"
+title: "Safe Subscriber Unregistration on Shutdown"
+status: "done"
+priority: "high"
+created_date: "2026-05-18"
+last_updated: "2026-05-18"
+---
+
+# ==========================================
+# STORY DEFINITION
+# ==========================================
+
+## Story
+
+As a subscriber,
+I want my OmniView instance to safely unregister from Oracle AQ on shutdown,
+So that stale subscribers don't accumulate in the queue and consume resources.
+
+## Background
+
+Epic 1 implemented per-subscriber procedure generation with funny names (e.g., BARNACLE). Subscribers are registered via `DBMS_AQADM.ADD_SUBSCRIBER` in `OMNI_TRACER_API.Register_Subscriber`. On shutdown, stale subscriber registrations accumulate in Oracle AQ because no unregistration logic exists.
+
+Story 3-3 adds a graceful unregistration path: when the event listener is stopped (either on app shutdown or connection switch), `DBMS_AQADM.REMOVE_SUBSCRIBER` is called with a 5-second timeout to prevent hanging.
+
+**Epic 1 status**: COMPLETE ✅
+**Epic 2 status**: COMPLETE ✅
+**Epic 3 Story 3-1**: COMPLETE ✅ (Drop Subscriber Procedure)
+**Epic 3 Story 3-2**: CANCELLED (parked — security risk)
+
+---
+
+## Acceptance Criteria
+
+**Given** OmniView is running with an active subscriber
+**When** the application shuts down gracefully (Ctrl+C, quit command, or OS signal)
+**Then** the subscriber is removed from Oracle AQ via `DBMS_AQADM.REMOVE_SUBSCRIBER`
+**And** any pending messages for the subscriber are cleaned up
+
+**Given** OmniView crashes or is killed forcefully
+**When** the application restarts
+**Then** it re-registers the subscriber (idempotent registration already handles this)
+**And** the stale subscriber from the previous session is overwritten
+
+**Given** a subscriber is unregistered
+**When** the subscriber re-registers on next startup
+**Then** the correlation rule is re-applied and message routing works correctly
+
+**Given** Oracle is unreachable during shutdown
+**When** unregistration times out (5 seconds)
+**Then** the application exits immediately without hanging
+**And** a warning is logged
+
+---
+
+## Tasks/Subtasks
+
+### Task 1: Add Unregister_Subscriber to SQL package
+
+**Files**: `assets/sql/Omni_Tracer.sql`
+
+**Implementation approach**:
+- Uncomment `--PROCEDURE Unregister_Subscriber(subscriber_name_ IN VARCHAR2);` in package spec (line 116)
+- Add body implementation after `Register_Subscriber` body — calls `DBMS_AQADM.REMOVE_SUBSCRIBER`
+- Idempotent: handle ORA-24036 (subscriber does not exist) gracefully — return success
+
+- [x] Uncomment Unregister_Subscriber declaration in package spec
+- [x] Add Unregister_Subscriber body after Register_Subscriber body
+- [x] Handle ORA-24036 (subscriber not found) as no-op success
+
+### Task 2: Add UnregisterSubscriber to DatabaseRepository interface and OracleAdapter
+
+**Files**: `internal/core/ports/repository.go`, `internal/adapter/storage/oracle/subscriptions.go`
+
+**Implementation approach**:
+- Add `UnregisterSubscriber(ctx context.Context, subscriber domain.Subscriber) error` to `DatabaseRepository` interface
+- Implement in `OracleAdapter` using `BEGIN OMNI_TRACER_API.Unregister_Subscriber(:subscriberName); END;`
+- Update ALL stub/mock implementations of `DatabaseRepository`:
+  - `internal/service/tracer/tracer_service_test.go` → `stubDatabaseRepository`
+  - `internal/service/subscribers/procedure_generator_test.go` → `stubDBRepo`
+  - `internal/adapter/ui/database_settings_test.go` → `MockDatabaseRepository`
+
+- [x] Add `UnregisterSubscriber` to `DatabaseRepository` interface in `repository.go`
+- [x] Implement `UnregisterSubscriber` in `oracle/subscriptions.go`
+- [x] Add stub `UnregisterSubscriber` to `tracer_service_test.go:stubDatabaseRepository`
+- [x] Add stub `UnregisterSubscriber` to `procedure_generator_test.go:stubDBRepo`
+- [x] Add stub `UnregisterSubscriber` to `database_settings_test.go:MockDatabaseRepository`
+
+### Task 3: Wire unregistration into TracerService.CancelConnectionListener
+
+**Files**: `internal/service/tracer/tracer_service.go`
+
+**Implementation approach**:
+- Add `activeSubscriber *domain.Subscriber` field to `TracerService` struct
+- In `StartEventListener`, set `ts.activeSubscriber = subscriber` before goroutines start
+- In `CancelConnectionListener`, after `listenerWg.Wait()`, call `ts.db.UnregisterSubscriber` with `context.WithTimeout(context.Background(), 5*time.Second)` if both `ts.db != nil` and `ts.activeSubscriber != nil`
+- On timeout or error, log warning and continue (do NOT block or return error)
+- Clear `ts.activeSubscriber = nil` after unregistration attempt
+
+- [x] Add `activeSubscriber *domain.Subscriber` field to `TracerService`
+- [x] Set `ts.activeSubscriber = subscriber` in `StartEventListener`
+- [x] Call `UnregisterSubscriber` with 5s timeout in `CancelConnectionListener`
+- [x] Log warning on error and continue — never block shutdown
+- [x] Clear `activeSubscriber` after attempt
+
+### Task 4: Verify OS signal handling (no new code needed)
+
+**Files**: `cmd/omniview/main.go` (read-only review)
+
+BubbleTea v2 handles SIGINT/SIGTERM — when the user presses Ctrl+C or the process receives a signal, `p.Run()` exits normally. The `defer` chain in `run()` then fires:
+- `defer closeLog()`
+- `defer boltAdapter.Close()`
+
+The TracerService cleanup (`CancelConnectionListener` → `UnregisterSubscriber`) is triggered by BubbleTea's quit path inside the UI model, which calls `StopConnectionListener`. No changes needed in `main.go`.
+
+- [x] Confirm `p.Run()` return → UI model's quit path → `StopConnectionListener` → `CancelConnectionListener` chain is sufficient
+- [x] Confirm no changes needed in `main.go`
+
+### Task 5: Unit tests for unregistration
+
+**Files**: `internal/service/tracer/tracer_service_test.go`
+
+**Tests to add**:
+1. `TestCancelConnectionListener_UnregistersActiveSubscriber` — TracerService with active subscriber, verify `UnregisterSubscriber` is called
+2. `TestCancelConnectionListener_SkipsUnregistrationWhenNoSubscriber` — no active subscriber, no error
+3. `TestCancelConnectionListener_ContinuesOnUnregisterError` — `UnregisterSubscriber` returns error, service still completes cleanly
+
+- [x] Add controllable `stubDatabaseRepositoryWithUnregister` or extend `stubDatabaseRepository`
+- [x] Add `TestCancelConnectionListener_UnregistersActiveSubscriber`
+- [x] Add `TestCancelConnectionListener_SkipsUnregistrationWhenNoSubscriber`
+- [x] Add `TestCancelConnectionListener_ContinuesOnUnregisterError`
+
+### Task 6: Build and test verification
+
+- [x] Run `make test` — all tests pass
+- [x] Run `make build` — binary builds successfully
+
+### Review Findings
+
+- [x] [Review][Patch] Unregistration unreachable on app quit — added `StopConnectionListener()` before `tea.Quit` in model.go quit handler [internal/adapter/ui/model.go:365-375]
+- [x] [Review][Patch] TOCTOU race on `activeSubscriber` — nil field before call, store local copy [internal/service/tracer/tracer_service.go:183-191]
+- [x] [Review][Patch] Stored pointer to caller-owned subscriber — store defensive copy in StartEventListener [internal/service/tracer/tracer_service.go:201-202]
+- [x] [Review][Defer] No test for 5s timeout boundary — pre-existing pattern, stdlib context.WithTimeout is trusted
+- [x] [Review][Defer] PL/SQL whitespace-only name passes NULL check — pre-existing gap in Register_Subscriber too
+- [x] [Review][Defer] Error message in subscriptions.go missing subscriber name — cosmetic, pre-existing pattern
+
+---
+
+## Dev Notes
+
+### Technical Context
+
+**TracerService location**: `internal/service/tracer/tracer_service.go`
+- `CancelConnectionListener()` — stops dequeue loop, waits for goroutines, drains channel
+- `StartEventListener(ctx, subscriber, schema)` — stores subscriber then starts goroutines
+- `ts.db` is `ports.DatabaseRepository` — call `UnregisterSubscriber` here
+
+**Register_Subscriber pattern** (reference for Unregister body):
+```sql
+PROCEDURE Register_Subscriber(subscriber_name_ IN VARCHAR2)
+IS
+    PRAGMA AUTONOMOUS_TRANSACTION;
+    sub_ SYS.AQ$_AGENT;
+BEGIN
+    sub_ := SYS.AQ$_AGENT(subscriber_name_, NULL, NULL);
+    DBMS_AQADM.ADD_SUBSCRIBER (
+        queue_name => TRACER_QUEUE_NAME,
+        subscriber => sub_,
+        rule       => 'tab.CORRELATION IS NULL OR tab.CORRELATION = ''' || subscriber_name_ || ''''
+    );
+    COMMIT;
+EXCEPTION
+WHEN OTHERS THEN
+    IF SQLCODE = -24034 THEN -- Subscriber already exists
+        COMMIT;
+    ELSE
+        ROLLBACK;
+        RAISE;
+    END IF;
+END Register_Subscriber;
+```
+
+**Unregister_Subscriber to implement** (mirror of Register, using REMOVE_SUBSCRIBER):
+- Oracle error for subscriber not found: ORA-24036 (SQLCODE = -24036)
+- Must be `PRAGMA AUTONOMOUS_TRANSACTION` (same as Register)
+
+**5-second timeout pattern**:
+```go
+unregCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+if err := ts.db.UnregisterSubscriber(unregCtx, *ts.activeSubscriber); err != nil {
+    logger.Warn("failed to unregister subscriber", "subscriber", ts.activeSubscriber.Name(), "error", err)
+}
+```
+
+**DatabaseRepository interface** (`internal/core/ports/repository.go`):
+- Add after `RegisterNewSubscriber`: `UnregisterSubscriber(ctx context.Context, subscriber domain.Subscriber) error`
+
+**Oracle implementation** (`internal/adapter/storage/oracle/subscriptions.go`):
+- Mirror `RegisterNewSubscriber` pattern: `BEGIN OMNI_TRACER_API.Unregister_Subscriber(:subscriberName); END;`
+- Use `subscriber.ConsumerName()` as the subscriber name (FunnyName)
+
+**Stub implementations to update** (add `return nil` no-ops):
+- `internal/service/tracer/tracer_service_test.go` → `stubDatabaseRepository`
+- `internal/service/subscribers/procedure_generator_test.go` → `stubDBRepo`
+- `internal/adapter/ui/database_settings_test.go` → `MockDatabaseRepository`
+
+### File Structure
+
+```
+assets/
+└── sql/
+    └── Omni_Tracer.sql                   # [MODIFY] Uncomment spec + add body
+internal/
+├── core/
+│   └── ports/
+│       └── repository.go                 # [MODIFY] Add UnregisterSubscriber to interface
+├── adapter/
+│   ├── storage/
+│   │   └── oracle/
+│   │       └── subscriptions.go          # [MODIFY] Implement UnregisterSubscriber
+│   └── ui/
+│       └── database_settings_test.go     # [MODIFY] Add stub method
+└── service/
+    ├── subscribers/
+    │   └── procedure_generator_test.go   # [MODIFY] Add stub method
+    └── tracer/
+        ├── tracer_service.go             # [MODIFY] activeSubscriber field, wiring
+        └── tracer_service_test.go        # [MODIFY] Stub + new tests
+```
+
+---
+
+## Dev Agent Record
+
+### Implementation Plan
+
+**Approach**: Added `Unregister_Subscriber` SQL procedure, wired `UnregisterSubscriber` through the port/oracle adapter, stored `activeSubscriber` in `TracerService`, and called `UnregisterSubscriber` with a 5-second timeout in `CancelConnectionListener`.
+
+**Files Modified**:
+- `assets/sql/Omni_Tracer.sql` — uncommented spec declaration + added `Unregister_Subscriber` body with ORA-24036 idempotent handling
+- `internal/core/ports/repository.go` — added `UnregisterSubscriber` to `DatabaseRepository` interface
+- `internal/adapter/storage/oracle/subscriptions.go` — implemented `UnregisterSubscriber`
+- `internal/service/tracer/tracer_service.go` — added `activeSubscriber` field, set in `StartEventListener`, called in `CancelConnectionListener` with 5s timeout
+- `internal/service/tracer/tracer_service_test.go` — added stub + 3 new tests
+- `internal/service/subscribers/procedure_generator_test.go` — added stub method
+- `internal/adapter/ui/database_settings_test.go` — added stub method
+
+### Debug Log
+
+- `CancelConnectionListener` already had nil guard — safe to add unregistration after `listenerWg.Wait()`
+- `time` package already imported in tracer_service.go — no new import needed
+- `main.go` requires no changes: BubbleTea v2 handles SIGINT/SIGTERM, UI model calls `StopConnectionListener` on quit
+- linker `-rpath` warnings in `make build` are pre-existing, unrelated to this story
+
+### Completion Notes
+
+✅ Story 3-3 completed: Safe Subscriber Unregistration on Shutdown implemented with:
+- `Unregister_Subscriber` PL/SQL procedure added to `OMNI_TRACER_API` (spec + body)
+- `UnregisterSubscriber` port method + Oracle adapter implementation
+- `activeSubscriber` stored in `TracerService`, cleared after unregistration
+- 5-second timeout on unregistration — never blocks shutdown
+- Errors logged as warnings and ignored — app exits cleanly
+- 3 new unit tests covering happy path, no-subscriber skip, and error continuation
+- `make test` ✅ — all tests pass
+- `make build` ✅ — binary built successfully
+
+---
+
+## File List
+
+**Modified:**
+- `assets/sql/Omni_Tracer.sql`
+- `internal/core/ports/repository.go`
+- `internal/adapter/storage/oracle/subscriptions.go`
+- `internal/service/tracer/tracer_service.go`
+- `internal/service/tracer/tracer_service_test.go`
+- `internal/service/subscribers/procedure_generator_test.go`
+- `internal/adapter/ui/database_settings_test.go`
+
+**Created:**
+- `_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md`
+
+---
+
+## Change Log
+
+- **2026-05-18**: Story created from Epic 3 requirements and sprint-status.yaml
+- **2026-05-18**: Implementation complete — all tasks done, make test and make build passing
+
+---
+
+## Status History
+
+| Date | Status | Notes |
+|------|--------|-------|
+| 2026-05-18 | ready-for-dev | Story created from Epic 3 requirements |
+| 2026-05-18 | in-progress | Implementation started |
+| 2026-05-18 | done | Implementation complete; make test and make build passing |

--- a/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
+++ b/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
@@ -8,9 +8,9 @@ created_date: "2026-05-18"
 last_updated: "2026-05-18"
 ---
 
-# ==========================================
+==========================================
 # STORY DEFINITION
-# ==========================================
+==========================================
 
 ## Story
 
@@ -138,12 +138,12 @@ The TracerService cleanup (`CancelConnectionListener` → `UnregisterSubscriber`
 
 ### Review Findings
 
-- [x] [Review][Patch] Unregistration unreachable on app quit — added `StopConnectionListener()` before `tea.Quit` in model.go quit handler [internal/adapter/ui/model.go:365-375]
-- [x] [Review][Patch] TOCTOU race on `activeSubscriber` — nil field before call, store local copy [internal/service/tracer/tracer_service.go:183-191]
-- [x] [Review][Patch] Stored pointer to caller-owned subscriber — store defensive copy in StartEventListener [internal/service/tracer/tracer_service.go:201-202]
-- [x] [Review][Defer] No test for 5s timeout boundary — pre-existing pattern, stdlib context.WithTimeout is trusted
-- [x] [Review][Defer] PL/SQL whitespace-only name passes NULL check — pre-existing gap in Register_Subscriber too
-- [x] [Review][Defer] Error message in subscriptions.go missing subscriber name — cosmetic, pre-existing pattern
+- [x] Review/Patch Unregistration unreachable on app quit — added `StopConnectionListener()` before `tea.Quit` in model.go quit handler [internal/adapter/ui/model.go:365-375]
+- [x] Review/Patch TOCTOU race on `activeSubscriber` — nil field before call, store local copy [internal/service/tracer/tracer_service.go:183-191]
+- [x] Review/Patch Stored pointer to caller-owned subscriber — store defensive copy in StartEventListener [internal/service/tracer/tracer_service.go:201-202]
+- [x] Review/Defer No test for 5s timeout boundary — pre-existing pattern, stdlib context.WithTimeout is trusted
+- [x] Review/Defer PL/SQL whitespace-only name passes NULL check — pre-existing gap in Register_Subscriber too
+- [x] Review/Defer Error message in subscriptions.go missing subscriber name — cosmetic, pre-existing pattern
 
 ---
 
@@ -208,7 +208,7 @@ if err := ts.db.UnregisterSubscriber(unregCtx, *ts.activeSubscriber); err != nil
 
 ### File Structure
 
-```
+```text
 assets/
 └── sql/
     └── Omni_Tracer.sql                   # [MODIFY] Uncomment spec + add body

--- a/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
+++ b/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
@@ -9,7 +9,9 @@ last_updated: "2026-05-18"
 ---
 
 ==========================================
+
 # STORY DEFINITION
+
 ==========================================
 
 ## Story
@@ -157,6 +159,7 @@ The TracerService cleanup (`CancelConnectionListener` → `UnregisterSubscriber`
 - `ts.db` is `ports.DatabaseRepository` — call `UnregisterSubscriber` here
 
 **Register_Subscriber pattern** (reference for Unregister body):
+
 ```sql
 PROCEDURE Register_Subscriber(subscriber_name_ IN VARCHAR2)
 IS
@@ -186,6 +189,7 @@ END Register_Subscriber;
 - Must be `PRAGMA AUTONOMOUS_TRANSACTION` (same as Register)
 
 **5-second timeout pattern**:
+
 ```go
 unregCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 defer cancel()

--- a/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
+++ b/_bmad-output/implementation-artifacts/stories/3-3-safe-subscriber-unregistration.md
@@ -65,11 +65,11 @@ Story 3-3 adds a graceful unregistration path: when the event listener is stoppe
 **Implementation approach**:
 - Uncomment `--PROCEDURE Unregister_Subscriber(subscriber_name_ IN VARCHAR2);` in package spec (line 116)
 - Add body implementation after `Register_Subscriber` body — calls `DBMS_AQADM.REMOVE_SUBSCRIBER`
-- Idempotent: handle ORA-24036 (subscriber does not exist) gracefully — return success
+- Idempotent: handle ORA-24035 (subscriber does not exist) gracefully — return success
 
 - [x] Uncomment Unregister_Subscriber declaration in package spec
 - [x] Add Unregister_Subscriber body after Register_Subscriber body
-- [x] Handle ORA-24036 (subscriber not found) as no-op success
+- [x] Handle ORA-24035 (subscriber not found) as no-op success
 
 ### Task 2: Add UnregisterSubscriber to DatabaseRepository interface and OracleAdapter
 
@@ -185,7 +185,7 @@ END Register_Subscriber;
 ```
 
 **Unregister_Subscriber to implement** (mirror of Register, using REMOVE_SUBSCRIBER):
-- Oracle error for subscriber not found: ORA-24036 (SQLCODE = -24036)
+- Oracle error for subscriber not found: ORA-24035 (SQLCODE = -24035)
 - Must be `PRAGMA AUTONOMOUS_TRANSACTION` (same as Register)
 
 **5-second timeout pattern**:
@@ -243,7 +243,7 @@ internal/
 **Approach**: Added `Unregister_Subscriber` SQL procedure, wired `UnregisterSubscriber` through the port/oracle adapter, stored `activeSubscriber` in `TracerService`, and called `UnregisterSubscriber` with a 5-second timeout in `CancelConnectionListener`.
 
 **Files Modified**:
-- `assets/sql/Omni_Tracer.sql` — uncommented spec declaration + added `Unregister_Subscriber` body with ORA-24036 idempotent handling
+- `assets/sql/Omni_Tracer.sql` — uncommented spec declaration + added `Unregister_Subscriber` body with ORA-24035 idempotent handling
 - `internal/core/ports/repository.go` — added `UnregisterSubscriber` to `DatabaseRepository` interface
 - `internal/adapter/storage/oracle/subscriptions.go` — implemented `UnregisterSubscriber`
 - `internal/service/tracer/tracer_service.go` — added `activeSubscriber` field, set in `StartEventListener`, called in `CancelConnectionListener` with 5s timeout

--- a/assets/sql/Omni_Tracer.sql
+++ b/assets/sql/Omni_Tracer.sql
@@ -227,7 +227,7 @@ CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
         COMMIT;
     EXCEPTION
     WHEN OTHERS THEN
-        IF SQLCODE = -24036 THEN -- Subscriber does not exist (ORA-24036)
+        IF SQLCODE = -24035 THEN -- Subscriber does not exist (ORA-24035)
             COMMIT; -- Must commit autonomous transaction even on expected exception
         ELSE
             ROLLBACK;

--- a/assets/sql/Omni_Tracer.sql
+++ b/assets/sql/Omni_Tracer.sql
@@ -113,7 +113,7 @@ CREATE OR REPLACE PACKAGE OMNI_TRACER_API AS
     
     -- Subscriber Management
     PROCEDURE Register_Subscriber(subscriber_name_ IN VARCHAR2);
-    --PROCEDURE Unregister_Subscriber(subscriber_name_ IN VARCHAR2);
+    PROCEDURE Unregister_Subscriber(subscriber_name_ IN VARCHAR2);
 
 END OMNI_TRACER_API;
 /
@@ -204,6 +204,32 @@ CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
             RAISE;
         END IF;
     END Register_Subscriber;
+
+
+    PROCEDURE Unregister_Subscriber(subscriber_name_ IN VARCHAR2)
+    IS
+        PRAGMA AUTONOMOUS_TRANSACTION;
+        sub_ SYS.AQ$_AGENT;
+    BEGIN
+        IF subscriber_name_ IS NULL THEN
+            RAISE_APPLICATION_ERROR(-20001, 'Subscriber name cannot be NULL or empty');
+        END IF;
+
+        sub_ := SYS.AQ$_AGENT(subscriber_name_, NULL, NULL);
+        DBMS_AQADM.REMOVE_SUBSCRIBER (
+            queue_name => TRACER_QUEUE_NAME,
+            subscriber => sub_
+        );
+        COMMIT;
+    EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLCODE = -24036 THEN -- Subscriber does not exist (ORA-24036)
+            COMMIT; -- Must commit autonomous transaction even on expected exception
+        ELSE
+            ROLLBACK;
+            RAISE;
+        END IF;
+    END Unregister_Subscriber;
 
 
     PROCEDURE Enqueue_Event___ (

--- a/assets/sql/Omni_Tracer.sql
+++ b/assets/sql/Omni_Tracer.sql
@@ -215,6 +215,10 @@ CREATE OR REPLACE PACKAGE BODY OMNI_TRACER_API AS
             RAISE_APPLICATION_ERROR(-20001, 'Subscriber name cannot be NULL or empty');
         END IF;
 
+        IF NOT REGEXP_LIKE(subscriber_name_, '^[A-Za-z0-9_]+$') THEN
+            RAISE_APPLICATION_ERROR(-20002, 'Subscriber name contains invalid characters. Only alphanumeric and underscores are allowed.');
+        END IF;
+
         sub_ := SYS.AQ$_AGENT(subscriber_name_, NULL, NULL);
         DBMS_AQADM.REMOVE_SUBSCRIBER (
             queue_name => TRACER_QUEUE_NAME,

--- a/internal/adapter/storage/oracle/subscriptions.go
+++ b/internal/adapter/storage/oracle/subscriptions.go
@@ -64,3 +64,15 @@ func parseCountResult(results []string) (int, error) {
 	}
 	return count, nil
 }
+
+// UnregisterSubscriber removes a subscriber from Oracle AQ.
+// If the subscriber does not exist, it returns nil (idempotent).
+func (oa *OracleAdapter) UnregisterSubscriber(ctx context.Context, subscriber domain.Subscriber) error {
+	err := oa.ExecuteWithParams(ctx, "BEGIN OMNI_TRACER_API.Unregister_Subscriber(:subscriberName); END;", map[string]interface{}{
+		"subscriberName": subscriber.ConsumerName(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to unregister subscriber: %w", err)
+	}
+	return nil
+}

--- a/internal/adapter/ui/database_settings_test.go
+++ b/internal/adapter/ui/database_settings_test.go
@@ -102,6 +102,11 @@ func (m *MockDatabaseRepository) RegisterNewSubscriber(ctx context.Context, subs
 	return nil
 }
 
+// UnregisterSubscriber implements ports.DatabaseRepository (no-op for mock).
+func (m *MockDatabaseRepository) UnregisterSubscriber(ctx context.Context, subscriber domain.Subscriber) error {
+	return nil
+}
+
 // BulkDequeueTracerMessages implements ports.DatabaseRepository (no-op for mock).
 func (m *MockDatabaseRepository) BulkDequeueTracerMessages(ctx context.Context, subscriber domain.Subscriber) ([]string, [][]byte, int, error) {
 	return nil, nil, 0, nil

--- a/internal/adapter/ui/model.go
+++ b/internal/adapter/ui/model.go
@@ -363,11 +363,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "ctrl+c":
+			if m.tracerService != nil {
+				m.tracerService.StopConnectionListener()
+			}
 			m.cancel() // Cancel all background operations
 			return m, tea.Quit
 		case "q":
 			// Only quit from screens that don't need 'q' for navigation
 			if (m.screen == screenMain && !m.dbSettings.visible && !m.webhookSettings.visible) || m.screen == screenWelcome || (m.screen == screenLoading && !m.dbSettings.visible) {
+				if m.tracerService != nil {
+					m.tracerService.StopConnectionListener()
+				}
 				m.cancel()
 				return m, tea.Quit
 			}

--- a/internal/core/ports/repository.go
+++ b/internal/core/ports/repository.go
@@ -76,6 +76,10 @@ type DatabaseRepository interface {
 	// RegisterNewSubscriber registers a new subscriber in the database
 	RegisterNewSubscriber(ctx context.Context, subscriber domain.Subscriber) error
 
+	// UnregisterSubscriber removes a subscriber from Oracle AQ.
+	// Returns nil if the subscriber does not exist (idempotent).
+	UnregisterSubscriber(ctx context.Context, subscriber domain.Subscriber) error
+
 	// BulkDequeueTracerMessages dequeues multiple messages for a subscriber
 	BulkDequeueTracerMessages(ctx context.Context, subscriber domain.Subscriber) ([]string, [][]byte, int, error)
 

--- a/internal/service/subscribers/procedure_generator_test.go
+++ b/internal/service/subscribers/procedure_generator_test.go
@@ -45,6 +45,10 @@ func (s *stubDBRepo) RegisterNewSubscriber(ctx context.Context, subscriber domai
 	return s.registerErr
 }
 
+func (s *stubDBRepo) UnregisterSubscriber(ctx context.Context, subscriber domain.Subscriber) error {
+	return nil
+}
+
 func (s *stubDBRepo) BulkDequeueTracerMessages(ctx context.Context, subscriber domain.Subscriber) ([]string, [][]byte, int, error) {
 	return nil, nil, 0, nil
 }

--- a/internal/service/tracer/tracer_service.go
+++ b/internal/service/tracer/tracer_service.go
@@ -130,13 +130,14 @@ func StopAll(tracerService *TracerService) {
 // Service: Manages package deployments
 // Injects a DatabaseRepository and ConfigRepository to interact with the database
 type TracerService struct {
-	db             ports.DatabaseRepository
-	bolt           ports.ConfigRepository
-	processMu      sync.Mutex
-	eventChannel   chan *domain.QueueMessage
-	listenerCtx    context.Context
-	listenerCancel context.CancelFunc
-	listenerWg     sync.WaitGroup
+	db               ports.DatabaseRepository
+	bolt             ports.ConfigRepository
+	processMu        sync.Mutex
+	eventChannel     chan *domain.QueueMessage
+	listenerCtx      context.Context
+	listenerCancel   context.CancelFunc
+	listenerWg       sync.WaitGroup
+	activeSubscriber *domain.Subscriber
 }
 
 // Constructor: NewTracerService Constructor for TracerService
@@ -166,6 +167,8 @@ func (ts *TracerService) StopConnectionListener() {
 }
 
 // CancelConnectionListener stops the current connection-scoped listener and waits for its goroutines to exit.
+// If a subscriber is active, it is unregistered from Oracle AQ with a 5-second timeout.
+// Unregistration errors are logged but never block shutdown.
 func (ts *TracerService) CancelConnectionListener() {
 	if ts == nil {
 		return
@@ -177,6 +180,16 @@ func (ts *TracerService) CancelConnectionListener() {
 		ts.listenerCtx = nil
 	}
 	ts.drainEventChannel()
+
+	if ts.db != nil && ts.activeSubscriber != nil {
+		sub := *ts.activeSubscriber
+		ts.activeSubscriber = nil // nil before call to prevent TOCTOU race
+		unregCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := ts.db.UnregisterSubscriber(unregCtx, sub); err != nil {
+			logger.Warn("failed to unregister subscriber from Oracle AQ", "consumer", sub.ConsumerName(), "error", err)
+		}
+	}
 }
 
 // StartEventListener starts goroutines that listen for new tracer messages for the given subscriber and processes them
@@ -185,6 +198,9 @@ func (ts *TracerService) StartEventListener(ctx context.Context, subscriber *dom
 		return fmt.Errorf("subscriber cannot be nil")
 	}
 	ts.StopConnectionListener()
+
+	subCopy := *subscriber
+	ts.activeSubscriber = &subCopy
 
 	// Create a cancellable context for event listeners
 	ts.listenerCtx, ts.listenerCancel = context.WithCancel(ctx)

--- a/internal/service/tracer/tracer_service.go
+++ b/internal/service/tracer/tracer_service.go
@@ -133,6 +133,7 @@ type TracerService struct {
 	db               ports.DatabaseRepository
 	bolt             ports.ConfigRepository
 	processMu        sync.Mutex
+	subscriberMu     sync.Mutex
 	eventChannel     chan *domain.QueueMessage
 	listenerCtx      context.Context
 	listenerCancel   context.CancelFunc
@@ -181,12 +182,19 @@ func (ts *TracerService) CancelConnectionListener() {
 	}
 	ts.drainEventChannel()
 
-	if ts.db != nil && ts.activeSubscriber != nil {
-		sub := *ts.activeSubscriber
-		ts.activeSubscriber = nil // nil before call to prevent TOCTOU race
+	ts.subscriberMu.Lock()
+	var sub *domain.Subscriber
+	if ts.activeSubscriber != nil {
+		copy := *ts.activeSubscriber
+		sub = &copy
+		ts.activeSubscriber = nil
+	}
+	ts.subscriberMu.Unlock()
+
+	if ts.db != nil && sub != nil {
 		unregCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := ts.db.UnregisterSubscriber(unregCtx, sub); err != nil {
+		if err := ts.db.UnregisterSubscriber(unregCtx, *sub); err != nil {
 			logger.Warn("failed to unregister subscriber from Oracle AQ", "consumer", sub.ConsumerName(), "error", err)
 		}
 	}
@@ -199,8 +207,10 @@ func (ts *TracerService) StartEventListener(ctx context.Context, subscriber *dom
 	}
 	ts.StopConnectionListener()
 
-	subCopy := *subscriber
-	ts.activeSubscriber = &subCopy
+	ts.subscriberMu.Lock()
+	ts.activeSubscriber = new(domain.Subscriber)
+	*ts.activeSubscriber = *subscriber
+	ts.subscriberMu.Unlock()
 
 	// Create a cancellable context for event listeners
 	ts.listenerCtx, ts.listenerCancel = context.WithCancel(ctx)

--- a/internal/service/tracer/tracer_service_test.go
+++ b/internal/service/tracer/tracer_service_test.go
@@ -29,6 +29,9 @@ func (stubDatabaseRepository) Close(context.Context) error   { return nil }
 func (stubDatabaseRepository) RegisterNewSubscriber(context.Context, domain.Subscriber) error {
 	return nil
 }
+func (stubDatabaseRepository) UnregisterSubscriber(context.Context, domain.Subscriber) error {
+	return nil
+}
 func (stubDatabaseRepository) BulkDequeueTracerMessages(context.Context, domain.Subscriber) ([]string, [][]byte, int, error) {
 	return nil, nil, 0, nil
 }
@@ -138,4 +141,100 @@ func TestWebhookDispatcherStop_IsIdempotent(t *testing.T) {
 	dispatcher := newWebhookDispatcher()
 	dispatcher.Stop()
 	dispatcher.Stop()
+}
+
+// spyDatabaseRepository is a controllable stub that tracks UnregisterSubscriber calls.
+type spyDatabaseRepository struct {
+	stubDatabaseRepository
+	mu                    sync.Mutex
+	unregisterCalled      bool
+	unregisterCalledWith  domain.Subscriber
+	unregisterErr         error
+}
+
+func (s *spyDatabaseRepository) UnregisterSubscriber(_ context.Context, sub domain.Subscriber) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unregisterCalled = true
+	s.unregisterCalledWith = sub
+	return s.unregisterErr
+}
+
+func newTestSubscriber(t *testing.T) *domain.Subscriber {
+	t.Helper()
+	sub, err := domain.NewSubscriber("TESTNAME", domain.DefaultBatchSize, domain.DefaultWaitTime)
+	if err != nil {
+		t.Fatalf("failed to create test subscriber: %v", err)
+	}
+	return sub
+}
+
+func TestCancelConnectionListener_UnregistersActiveSubscriber(t *testing.T) {
+	t.Parallel()
+	spy := &spyDatabaseRepository{}
+	sub := newTestSubscriber(t)
+
+	ts := &TracerService{
+		db:               spy,
+		eventChannel:     make(chan *domain.QueueMessage, 1),
+		activeSubscriber: sub,
+	}
+
+	ts.CancelConnectionListener()
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if !spy.unregisterCalled {
+		t.Fatal("expected UnregisterSubscriber to be called when an active subscriber is present")
+	}
+	if spy.unregisterCalledWith.ConsumerName() != sub.ConsumerName() {
+		t.Fatalf("expected UnregisterSubscriber called with %q, got %q",
+			sub.ConsumerName(), spy.unregisterCalledWith.ConsumerName())
+	}
+	if ts.activeSubscriber != nil {
+		t.Fatal("expected activeSubscriber to be cleared after unregistration")
+	}
+}
+
+func TestCancelConnectionListener_SkipsUnregistrationWhenNoSubscriber(t *testing.T) {
+	t.Parallel()
+	spy := &spyDatabaseRepository{}
+
+	ts := &TracerService{
+		db:           spy,
+		eventChannel: make(chan *domain.QueueMessage, 1),
+		// activeSubscriber intentionally nil
+	}
+
+	ts.CancelConnectionListener()
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if spy.unregisterCalled {
+		t.Fatal("expected UnregisterSubscriber NOT to be called when no active subscriber")
+	}
+}
+
+func TestCancelConnectionListener_ContinuesOnUnregisterError(t *testing.T) {
+	t.Parallel()
+	spy := &spyDatabaseRepository{unregisterErr: errors.New("oracle unreachable")}
+	sub := newTestSubscriber(t)
+
+	ts := &TracerService{
+		db:               spy,
+		eventChannel:     make(chan *domain.QueueMessage, 1),
+		activeSubscriber: sub,
+	}
+
+	// Must not panic or block — error is only logged
+	ts.CancelConnectionListener()
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if !spy.unregisterCalled {
+		t.Fatal("expected UnregisterSubscriber to be called even when an error is expected")
+	}
+	if ts.activeSubscriber != nil {
+		t.Fatal("expected activeSubscriber to be cleared even after unregistration error")
+	}
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a robust mechanism for safely unregistering active subscribers from Oracle AQ when the OmniView application shuts down. This prevents the accumulation of stale subscriber registrations in the queue, which could otherwise consume resources and lead to management overhead.

Key changes and their functional impact include:

*   **Oracle AQ Integration**: A new PL/SQL procedure, `OMNI_TRACER_API.Unregister_Subscriber`, has been added to the Oracle database package. This procedure utilizes `DBMS_AQADM.REMOVE_SUBSCRIBER` to remove a specified subscriber. It is designed to be **idempotent**, gracefully handling cases where the subscriber might not exist (`ORA-24036`) by committing the autonomous transaction without raising an error. This ensures that repeated unregistration attempts or attempts for already-removed subscribers do not cause issues.
*   **Application Shutdown Hook**: The `TracerService` in the Go application now stores a reference to the `activeSubscriber`. During the application's shutdown sequence, specifically within the `CancelConnectionListener` method, this active subscriber is unregistered.
*   **Non-Blocking Timeout Handling**: The unregistration call is executed with a **5-second timeout** using `context.WithTimeout`. If the Oracle database is unreachable or the unregistration operation exceeds this duration, the attempt is aborted. Any errors encountered during unregistration are **logged as warnings but do not block the application's shutdown process**, ensuring a swift and graceful exit regardless of database connectivity.
*   **Robustness Improvements**:
    *   To prevent a Time-of-Check-to-Time-of-Use (TOCTOU) race condition, the `activeSubscriber` field is cleared *before* the unregistration call, and a defensive copy of the subscriber is used for the operation.
    *   A defensive copy of the subscriber is stored in `TracerService.activeSubscriber` when `StartEventListener` is called, preventing unintended modifications from the caller.
*   **User Interface Integration**: Crucially, the `internal/adapter/ui/model.go` file has been modified to explicitly call `m.tracerService.StopConnectionListener()` when the user quits the application via `Ctrl+C` or the 'q' key. This ensures that the unregistration logic is reliably triggered during user-initiated graceful shutdowns.
*   **Comprehensive Unit Testing**: Three new unit tests have been added to `tracer_service_test.go` to verify the unregistration mechanism's behavior:
    *   Successful unregistration of an active subscriber.
    *   Correctly skipping unregistration when no subscriber is active.
    *   Ensuring the application continues to shut down cleanly even if the unregistration process encounters an error.
*   **Interface and Adapter Updates**: The `DatabaseRepository` interface has been extended with an `UnregisterSubscriber` method, and its `OracleAdapter` implementation now bridges to the new PL/SQL procedure. Mock and stub implementations across the test suite have been updated to conform to this new interface.

These changes collectively fulfill the requirement for safe and reliable subscriber unregistration, enhancing the application's stability and resource management within the Oracle AQ environment.
<!-- kody-pr-summary:end -->