### PR TITLE
feat: implement platform-specific process detachment for Unix and Win…

### DIFF
--- a/internal/updater/restart_unix.go
+++ b/internal/updater/restart_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package updater
+
+import "syscall"
+
+// detachSysProcAttr returns the platform-specific SysProcAttr needed to make
+// the spawned child survive its parent's exit. On Unix systems, Setsid starts
+// the child in a new session so signals delivered to the parent's process group
+// (e.g. SIGHUP from a closing terminal) are not forwarded to the new instance.
+func detachSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/updater/restart_windows.go
+++ b/internal/updater/restart_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package updater
+
+import "syscall"
+
+// createNewProcessGroup is the Windows CREATE_NEW_PROCESS_GROUP creation flag
+// (0x00000200). It detaches the child from the parent's process group so that
+// Ctrl+Break / console-close signals delivered to the parent are not forwarded
+// to the new instance.
+const createNewProcessGroup = 0x00000200
+
+// detachSysProcAttr returns the platform-specific SysProcAttr needed to make
+// the spawned child survive its parent's exit. On Windows this is the
+// CREATE_NEW_PROCESS_GROUP creation flag.
+func detachSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: createNewProcessGroup}
+}

--- a/internal/updater/signature.go
+++ b/internal/updater/signature.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
@@ -61,7 +62,7 @@ func mustDecodePublicKey(b64 string) ed25519.PublicKey {
 // Returns (false, nil) when signature verification is disabled (no public key
 // configured). Returns (true, nil) when the signature is valid. Returns (false, err)
 // when a key is configured but the signature is missing, malformed, or invalid.
-func verifyChecksumFileSignature(release *githubRelease, checksumAssetName, checksumData string) (bool, error) {
+func verifyChecksumFileSignature(ctx context.Context, release *githubRelease, checksumAssetName, checksumData string) (bool, error) {
 	if len(signaturePublicKey) == 0 {
 		// Signing not yet provisioned; integrity is still covered by the checksum.
 		return false, nil
@@ -72,7 +73,7 @@ func verifyChecksumFileSignature(release *githubRelease, checksumAssetName, chec
 		return false, fmt.Errorf("%w for %s", errSignatureRequired, checksumAssetName)
 	}
 
-	sigBytes, err := downloadSignature(sigURL)
+	sigBytes, err := downloadSignature(ctx, sigURL)
 	if err != nil {
 		return false, fmt.Errorf("failed to download signature: %w", err)
 	}
@@ -99,9 +100,13 @@ func findSignatureAssetURL(release *githubRelease, checksumAssetName string) str
 
 // downloadSignature fetches and decodes a detached signature. The signature may be
 // stored raw (64 bytes), base64-encoded, or hex-encoded.
-func downloadSignature(url string) ([]byte, error) {
+func downloadSignature(ctx context.Context, url string) ([]byte, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/updater/signature_test.go
+++ b/internal/updater/signature_test.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
@@ -11,7 +12,7 @@ func TestVerifyChecksumFileSignatureDisabledWhenNoKey(t *testing.T) {
 	defer func(prev ed25519.PublicKey) { signaturePublicKey = prev }(signaturePublicKey)
 	signaturePublicKey = nil
 
-	verified, err := verifyChecksumFileSignature(&githubRelease{}, "checksums.txt", "data")
+	verified, err := verifyChecksumFileSignature(context.Background(), &githubRelease{}, "checksums.txt", "data")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -29,7 +30,7 @@ func TestVerifyChecksumFileSignatureRequiresAssetWhenKeySet(t *testing.T) {
 	signaturePublicKey = pub
 
 	// Release has no .sig asset -> fail-closed.
-	_, err = verifyChecksumFileSignature(&githubRelease{}, "checksums.txt", "data")
+	_, err = verifyChecksumFileSignature(context.Background(), &githubRelease{}, "checksums.txt", "data")
 	if err == nil {
 		t.Fatal("expected error when signature asset is missing")
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -898,13 +898,14 @@ func restartSelf(selfPath string) error {
 	case result := <-waitCh:
 		// A clean exit (e.g. the new version printed a one-shot message and
 		// exited 0 within the grace period) is a successful run, not a failure
-		// to start. Do not roll back and do not report an error in that case.
+		// to start. The new binary is on disk; terminate the parent so the
+		// running process matches the reported successful update.
 		if result.err == nil && result.state.Success() {
-			return nil
+			os.Exit(0)
 		}
 		if hadOldBackup {
 			if restoreErr := restoreOldBackups(selfPath); restoreErr != nil {
-				return fmt.Errorf("restart: child exited (%v) and restore failed: %w", result.err, restoreErr)
+				return fmt.Errorf("restart: child exited (state: %s) and restore failed: %w", result.state, restoreErr)
 			}
 		}
 		if result.err != nil {
@@ -940,7 +941,13 @@ func restoreOldBackups(selfPath string) error {
 			continue
 		}
 		for _, match := range matches {
-			if err := os.Rename(match, strings.TrimSuffix(match, ".old")); err != nil && !os.IsNotExist(err) {
+			dest := strings.TrimSuffix(match, ".old")
+			// os.Rename on Windows fails if the destination already exists; the
+			// replaceFile path overwrote it with the new file, so remove it first.
+			if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove %s: %w", dest, err)
+			}
+			if err := os.Rename(match, dest); err != nil && !os.IsNotExist(err) {
 				return fmt.Errorf("rename %s: %w", match, err)
 			}
 		}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"OmniView/internal/adapter/logger"
 	"OmniView/internal/core/domain"
 	"archive/tar"
 	"archive/zip"
@@ -138,7 +139,7 @@ func DownloadAndApply(ctx context.Context, info *UpdateInfo, progressFn func(sta
 	}
 
 	progress("Verifying checksum...")
-	if _, err := verifyChecksum(tmpFile, release, expectedAssetName(info.NewVersion)); err != nil {
+	if _, err := verifyChecksum(ctx, tmpFile, release, expectedAssetName(info.NewVersion)); err != nil {
 		return fmt.Errorf("checksum verification failed: %w", err)
 	}
 	// verified == false with err == nil means no checksum file was found - skip verification
@@ -162,9 +163,15 @@ func DownloadAndApply(ctx context.Context, info *UpdateInfo, progressFn func(sta
 		return fmt.Errorf("extraction failed: %w", err)
 	}
 
-	// Write RELEASE_NOTES.md in the same directory as the binary
+	// Write RELEASE_NOTES.md in the same directory as the binary. A failure here
+	// is non-fatal — the binary has already been swapped in and the user can
+	// still read release notes from GitHub — but it is logged for diagnosis.
 	if err := writeReleaseNotes(selfDir, release); err != nil {
-		fmt.Printf("[updater] writeReleaseNotes failed for release %v at %s: %v\n", release.TagName, selfDir, err)
+		logger.Error("writeReleaseNotes failed",
+			"release", release.TagName,
+			"dir", selfDir,
+			"err", err,
+		)
 	}
 
 	// Clean up temp archive before restart (defers won't run after os.Exit)
@@ -176,13 +183,17 @@ func DownloadAndApply(ctx context.Context, info *UpdateInfo, progressFn func(sta
 	return restartSelf(selfPath)
 }
 
-// CheckAndUpdate checks the latest GitHub release and prompts the user to update.
+// checkAndUpdate checks the latest GitHub release and prompts the user to update.
 // currentVersion is the version string embedded in the binary at build time (e.g. "v0.2.0").
 // Returns nil if no update is needed or the user declines. Returns an error on failure.
 //
 // Deprecated: Use CheckForUpdate followed by DownloadAndApply instead.
-// This function is kept for backward compatibility.
-func CheckAndUpdate(currentVersion string) error {
+// This function is kept for backward compatibility with non-TUI entry points and
+// the CLI updater. It uses fmt.Scanln for interactive prompting, which is not
+// safe to invoke from within a Bubble Tea program (the TUI owns stdin/stdout).
+// Unexported because all in-process callers should go through the TUI's
+// UpdaterService, which uses CheckForUpdate + DownloadAndApply.
+func checkAndUpdate(currentVersion string) error {
 	info, err := CheckForUpdate(context.Background(), currentVersion)
 	if err != nil {
 		fmt.Printf("[updater] Could not check for updates: %v\n", err)
@@ -366,7 +377,7 @@ func downloadToTemp(ctx context.Context, url string) (string, error) {
 // and compares the computed hash against the expected value.
 // Returns (true, nil) when checksum is verified, (false, nil) when no checksum file exists,
 // and (false, err) for verification failures.
-func verifyChecksum(tmpFile string, release *githubRelease, assetName string) (bool, error) {
+func verifyChecksum(ctx context.Context, tmpFile string, release *githubRelease, assetName string) (bool, error) {
 	// Try to find a checksum file in the release assets
 	// Common patterns: <asset>.sha256, checksums.txt, SHA256SUMS, etc.
 	var checksumURL string
@@ -404,14 +415,14 @@ func verifyChecksum(tmpFile string, release *githubRelease, assetName string) (b
 	}
 
 	// Download the checksum file
-	checksumData, err := downloadChecksumFile(checksumURL)
+	checksumData, err := downloadChecksumFile(ctx, checksumURL)
 	if err != nil {
 		return false, fmt.Errorf("failed to download checksum file %s: %w", checksumAssetName, err)
 	}
 
 	// Authenticate the checksum file with a detached signature when release signing
 	// is provisioned. This is fail-closed: a configured key requires a valid signature.
-	if _, err := verifyChecksumFileSignature(release, checksumAssetName, checksumData); err != nil {
+	if _, err := verifyChecksumFileSignature(ctx, release, checksumAssetName, checksumData); err != nil {
 		return false, fmt.Errorf("signature verification failed: %w", err)
 	}
 
@@ -436,9 +447,15 @@ func verifyChecksum(tmpFile string, release *githubRelease, assetName string) (b
 }
 
 // downloadChecksumFile downloads the checksum file and returns its content as a string.
-func downloadChecksumFile(url string) (string, error) {
+// The context is used to cancel the in-flight HTTP request; checksum files are tiny
+// (a few hundred bytes), so no separate size cap is required.
+func downloadChecksumFile(ctx context.Context, url string) (string, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -832,21 +849,66 @@ func writeReleaseNotes(dir string, release *githubRelease) error {
 	return os.WriteFile(path, []byte(content), 0644)
 }
 
+// restartGracePeriod is how long we wait after StartProcess returns to confirm
+// the child actually launched. If the child dies within this window — for
+// example because the new binary is corrupt or a required shared library
+// could not be loaded — we roll back to the .old backup instead of stranding
+// the user with a broken install.
+const restartGracePeriod = 500 * time.Millisecond
+
 // restartSelf launches a new instance of the binary and exits the current process.
+// The child is started in its own process group so signals sent to the parent's
+// group (e.g. SIGHUP from a closing terminal) do not propagate to the new instance.
+// If the child exits within restartGracePeriod the previous binary is restored
+// from the .old backup and an error is returned without exiting the parent.
 func restartSelf(selfPath string) error {
 	args := os.Args
 	env := os.Environ()
+	oldPath := selfPath + ".old"
+
+	// Record whether a .old backup exists so we know whether restoration is
+	// possible if the new child fails to start.
+	hadOldBackup := false
+	if _, err := os.Stat(oldPath); err == nil {
+		hadOldBackup = true
+	}
 
 	proc, err := os.StartProcess(selfPath, args, &os.ProcAttr{
 		Dir:   filepath.Dir(selfPath),
 		Env:   env,
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+		Sys:   detachSysProcAttr(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to restart: %w", err)
 	}
 
-	// Detach the child so it survives our exit
+	// Wait briefly to confirm the child actually started.
+	type waitResult struct {
+		state *os.ProcessState
+		err   error
+	}
+	waitCh := make(chan waitResult, 1)
+	go func() {
+		state, err := proc.Wait()
+		waitCh <- waitResult{state: state, err: err}
+	}()
+
+	select {
+	case result := <-waitCh:
+		if hadOldBackup {
+			if renameErr := os.Rename(oldPath, selfPath); renameErr != nil {
+				return fmt.Errorf("restart: child exited (%v) and restore of %s failed: %w", result.err, oldPath, renameErr)
+			}
+		}
+		if result.err != nil {
+			return fmt.Errorf("restart: child process exited immediately: %w", result.err)
+		}
+		return fmt.Errorf("restart: child process exited immediately (state: %s)", result.state)
+	case <-time.After(restartGracePeriod):
+	}
+
+	// Detach the child so it survives our exit.
 	proc.Release()
 	os.Exit(0)
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -942,6 +942,16 @@ func restoreOldBackups(selfPath string) error {
 		}
 		for _, match := range matches {
 			dest := strings.TrimSuffix(match, ".old")
+			// Verify the .old backup still exists before deleting dest. If it
+			// has already been removed (e.g. by a prior partial rollback,
+			// manual cleanup, or an external process), skip the swap so we do
+			// not delete the only working copy.
+			if _, err := os.Stat(match); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return fmt.Errorf("stat %s: %w", match, err)
+			}
 			// os.Rename on Windows fails if the destination already exists; the
 			// replaceFile path overwrote it with the new file, so remove it first.
 			if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -896,9 +896,15 @@ func restartSelf(selfPath string) error {
 
 	select {
 	case result := <-waitCh:
+		// A clean exit (e.g. the new version printed a one-shot message and
+		// exited 0 within the grace period) is a successful run, not a failure
+		// to start. Do not roll back and do not report an error in that case.
+		if result.err == nil && result.state.Success() {
+			return nil
+		}
 		if hadOldBackup {
-			if renameErr := os.Rename(oldPath, selfPath); renameErr != nil {
-				return fmt.Errorf("restart: child exited (%v) and restore of %s failed: %w", result.err, oldPath, renameErr)
+			if restoreErr := restoreOldBackups(selfPath); restoreErr != nil {
+				return fmt.Errorf("restart: child exited (%v) and restore failed: %w", result.err, restoreErr)
 			}
 		}
 		if result.err != nil {
@@ -913,4 +919,31 @@ func restartSelf(selfPath string) error {
 	os.Exit(0)
 
 	return nil // Unreachable, but satisfies the compiler
+}
+
+// restoreOldBackups renames the binary's ".old" backup and any sibling shared
+// library ".old" backups in the same directory back to their original names.
+// Mirrors the platform-specific pattern list used by CleanupOldBinary.
+func restoreOldBackups(selfPath string) error {
+	if err := os.Rename(selfPath+".old", selfPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("rename %s.old: %w", selfPath, err)
+	}
+	var patterns []string
+	if runtime.GOOS == "windows" {
+		patterns = []string{"*.dll.old"}
+	} else {
+		patterns = []string{"*.dylib.old"}
+	}
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(filepath.Dir(selfPath), pattern))
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			if err := os.Rename(match, strings.TrimSuffix(match, ".old")); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("rename %s: %w", match, err)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR implements platform-specific process detachment, child process startup validation with rollback, and propagates request context through the updater's HTTP downloads for proper cancellation.

## Changes

### Platform-specific process detachment (new files)

- **`internal/updater/restart_unix.go`**: New file (build tag `!windows`) exporting `detachSysProcAttr()`, which returns `&syscall.SysProcAttr{Setsid: true}`. Starting the child in a new session prevents SIGHUP (or other signals delivered to the parent's process group when a terminal closes) from being forwarded to the new instance.
- **`internal/updater/restart_windows.go`**: New file (build tag `windows`) exporting `detachSysProcAttr()`, which returns `&syscall.SysProcAttr{CreationFlags: 0x00000200}` — the Windows `CREATE_NEW_PROCESS_GROUP` flag. This detaches the child from the parent's process group so that Ctrl+Break / console-close signals are not propagated.

### `restartSelf` robustness

The `restartSelf` function in `updater.go` now:
- Calls the new `detachSysProcAttr()` helper so the child survives parent exit on both platforms.
- Records whether a `.old` backup exists before launching the child.
- Waits for up to `restartGracePeriod` (500 ms) to confirm the child actually started. If the child exits within that window (e.g. the new binary is corrupt or missing a shared library), the `.old` backup is renamed back into place and an error is returned **without** calling `os.Exit(0)`, so the user is not left with a broken install.
- Only calls `proc.Release()` and `os.Exit(0)` after the grace period elapses successfully.

### Context propagation for HTTP downloads

`downloadChecksumFile`, `verifyChecksum`, `verifyChecksumFileSignature`, and `downloadSignature` now accept a `context.Context` and build requests with `http.NewRequestWithContext`, replacing bare `client.Get` calls. This allows the parent `DownloadAndApply` context to cancel in-flight HTTP requests (for example, on shutdown) instead of leaving them running to their 30-second timeout. The corresponding tests were updated to pass `context.Background()`.

### Logging and API cleanup

- `writeReleaseNotes` failures are now reported through the project's structured logger (`logger.Error`) instead of `fmt.Printf`, with `release`, `dir`, and `err` fields.
- `CheckAndUpdate` was renamed to `checkAndUpdate` (unexported) and its doc comment updated to clarify that in-process callers must go through the TUI's `UpdaterService` (`CheckForUpdate` + `DownloadAndApply`), since `fmt.Scanln`-based prompting is not safe inside a Bubble Tea program.
<!-- kody-pr-summary:end -->