### PR TITLE
fix: only require security key for encrypted data and refine UI labels

### DIFF
--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -53,11 +53,15 @@ func run(omniApp *app.App) error {
 				// a missing key. If no credentials are encrypted yet (i.e. legacy plaintext),
 				// we let database initialization automatically generate a new key file.
 				tempBA, err := boltdb.NewBoltAdapter(boltDBPath)
-				if err == nil {
-					hasEncrypted, scanErr := tempBA.HasEncryptedCredentials()
-					if scanErr == nil && hasEncrypted {
-						return fmt.Errorf("credential key %q is missing while %q already exists and contains encrypted credentials; restore the original key file or remove %q and reconfigure, otherwise stored credentials cannot be decrypted", keyPath, boltDBPath, boltDBPath)
-					}
+				if err != nil {
+					return fmt.Errorf("could not open BoltDB at %q to scan for encrypted credentials (key file: %q): %w", boltDBPath, keyPath, err)
+				}
+				hasEncrypted, scanErr := tempBA.HasEncryptedCredentials()
+				if scanErr != nil {
+					return fmt.Errorf("BoltDB encrypted-credentials scan failed on file %q (key file: %q): %w", boltDBPath, keyPath, scanErr)
+				}
+				if hasEncrypted {
+					return fmt.Errorf("credential key %q is missing while %q already exists and contains encrypted credentials; restore the original key file or remove %q and reconfigure, otherwise stored credentials cannot be decrypted", keyPath, boltDBPath, boltDBPath)
 				}
 			} else {
 				return fmt.Errorf("failed to stat credential key %s: %w", keyPath, keyErr)

--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -48,9 +48,20 @@ func run(omniApp *app.App) error {
 	if _, err := os.Stat(boltDBPath); err == nil {
 		if _, keyErr := os.Stat(keyPath); keyErr != nil {
 			if errors.Is(keyErr, os.ErrNotExist) {
-				return fmt.Errorf("credential key %q is missing while %q already exists; restore the original key file or remove %q and reconfigure, otherwise stored credentials cannot be decrypted", keyPath, boltDBPath, boltDBPath)
+				// To provide zero-friction upgrades for existing customers, we only block
+				// startup if the database actively contains encrypted credentials that need
+				// a missing key. If no credentials are encrypted yet (i.e. legacy plaintext),
+				// we let database initialization automatically generate a new key file.
+				tempBA, err := boltdb.NewBoltAdapter(boltDBPath)
+				if err == nil {
+					hasEncrypted, scanErr := tempBA.HasEncryptedCredentials()
+					if scanErr == nil && hasEncrypted {
+						return fmt.Errorf("credential key %q is missing while %q already exists and contains encrypted credentials; restore the original key file or remove %q and reconfigure, otherwise stored credentials cannot be decrypted", keyPath, boltDBPath, boltDBPath)
+					}
+				}
+			} else {
+				return fmt.Errorf("failed to stat credential key %s: %w", keyPath, keyErr)
 			}
-			return fmt.Errorf("failed to stat credential key %s: %w", keyPath, keyErr)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to stat BoltDB file %s: %w", boltDBPath, err)

--- a/internal/adapter/security/credcipher/cipher.go
+++ b/internal/adapter/security/credcipher/cipher.go
@@ -25,6 +25,15 @@ import (
 // compatibility with data written before encryption was enabled.
 const tokenPrefix = "enc:v1:"
 
+// ContainsEncryptedTokenInJSON reports whether s contains the canonical cipher
+// token marker as it appears inside a JSON-encoded credential value
+// (i.e. preceded by a JSON opening quote). It is safe to call without
+// constructing a Cipher and is the canonical predicate other packages
+// (e.g. the boltdb storage adapter) should use to detect ciphertext rows.
+func ContainsEncryptedTokenInJSON(s string) bool {
+	return strings.Contains(s, `"`+tokenPrefix)
+}
+
 // keySize is the AES-256 key length in bytes.
 const keySize = 32
 

--- a/internal/adapter/security/credcipher/cipher_test.go
+++ b/internal/adapter/security/credcipher/cipher_test.go
@@ -148,3 +148,27 @@ func TestFileKeyProviderTightensExistingPermissions(t *testing.T) {
 		t.Fatalf("key file perm = %o, want %o", perm, fileKeyPerm)
 	}
 }
+
+func TestContainsEncryptedTokenInJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"legacy plaintext only", `{"password": "plain_password"}`, false},
+		{"quoted token value", `{"password": "enc:v1:abc123"}`, true},
+		{"unquoted substring is not a JSON token", `enc:v1:abc123`, false},
+		{"token as JSON key", `{"enc:v1:":"x"}`, true},
+		{"plaintext plus token", `{"user":"plain","password":"enc:v1:abc123"}`, true},
+		{"prefix without JSON quote inside value", `{"password": "prefix-enc:v1:abc"}`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ContainsEncryptedTokenInJSON(tc.in); got != tc.want {
+				t.Fatalf("ContainsEncryptedTokenInJSON(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/security/credcipher/cipher_test.go
+++ b/internal/adapter/security/credcipher/cipher_test.go
@@ -161,7 +161,7 @@ func TestContainsEncryptedTokenInJSON(t *testing.T) {
 		{"unquoted substring is not a JSON token", `enc:v1:abc123`, false},
 		{"token as JSON key", `{"enc:v1:":"x"}`, true},
 		{"plaintext plus token", `{"user":"plain","password":"enc:v1:abc123"}`, true},
-		{"prefix without JSON quote inside value", `{"password": "prefix-enc:v1:abc"}`, false},
+		{"token not immediately after opening quote", `{"password": "prefix-enc:v1:abc"}`, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/adapter/storage/boltdb/bolt_adapter.go
+++ b/internal/adapter/storage/boltdb/bolt_adapter.go
@@ -534,9 +534,13 @@ func (ba *BoltAdapter) HasEncryptedCredentials() (bool, error) {
 			}
 			if strings.Contains(string(v), `"enc:v1:`) {
 				hasEncrypted = true
+				return domain.ErrEarlyAbort
 			}
 			return nil
 		})
 	})
+	if errors.Is(err, domain.ErrEarlyAbort) {
+		return true, nil
+	}
 	return hasEncrypted, err
 }

--- a/internal/adapter/storage/boltdb/bolt_adapter.go
+++ b/internal/adapter/storage/boltdb/bolt_adapter.go
@@ -2,6 +2,7 @@ package boltdb
 
 import (
 	"OmniView/internal/adapter/logger"
+	"OmniView/internal/adapter/security/credcipher"
 	"OmniView/internal/core/domain"
 	"OmniView/internal/core/ports"
 	"encoding/json"
@@ -503,7 +504,9 @@ func (ba *BoltAdapter) SetBroadcastMode(mode domain.BroadcastMode) error {
 }
 
 // HasEncryptedCredentials checks if this BoltDB instance contains any credentials
-// encrypted via the current format (prefixed with "enc:v1:").
+// encrypted via the current format. The detection delegates to
+// credcipher.ContainsEncryptedTokenInJSON so the wire-format marker stays
+// defined in exactly one place.
 // If the database is not initialized (db == nil), it temporarily opens the file read-only.
 func (ba *BoltAdapter) HasEncryptedCredentials() (bool, error) {
 	db := ba.db
@@ -532,7 +535,7 @@ func (ba *BoltAdapter) HasEncryptedCredentials() (bool, error) {
 			if string(k) == DefaultDatabaseConfigKey {
 				return nil
 			}
-			if strings.Contains(string(v), `"enc:v1:`) {
+			if credcipher.ContainsEncryptedTokenInJSON(string(v)) {
 				hasEncrypted = true
 				return domain.ErrEarlyAbort
 			}

--- a/internal/adapter/storage/boltdb/bolt_adapter.go
+++ b/internal/adapter/storage/boltdb/bolt_adapter.go
@@ -501,3 +501,42 @@ func (ba *BoltAdapter) SetBroadcastMode(mode domain.BroadcastMode) error {
 		return b.Put([]byte(BroadcastModeKey), []byte(mode.String()))
 	})
 }
+
+// HasEncryptedCredentials checks if this BoltDB instance contains any credentials
+// encrypted via the current format (prefixed with "enc:v1:").
+// If the database is not initialized (db == nil), it temporarily opens the file read-only.
+func (ba *BoltAdapter) HasEncryptedCredentials() (bool, error) {
+	db := ba.db
+	var shouldClose bool
+
+	if db == nil {
+		var err error
+		db, err = bolt.Open(ba.dbPath, 0600, &bolt.Options{ReadOnly: true, Timeout: 1 * time.Second})
+		if err != nil {
+			return false, err
+		}
+		shouldClose = true
+	}
+	if shouldClose {
+		defer db.Close()
+	}
+
+	hasEncrypted := false
+	err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(DatabaseConfigBucket))
+		if b == nil {
+			return nil
+		}
+		return b.ForEach(func(k, v []byte) error {
+			// Skip default key pointer or metadata configs
+			if string(k) == DefaultDatabaseConfigKey {
+				return nil
+			}
+			if strings.Contains(string(v), `"enc:v1:`) {
+				hasEncrypted = true
+			}
+			return nil
+		})
+	})
+	return hasEncrypted, err
+}

--- a/internal/adapter/storage/boltdb/bolt_adapter_test.go
+++ b/internal/adapter/storage/boltdb/bolt_adapter_test.go
@@ -1,0 +1,82 @@
+package boltdb
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestBoltAdapter_HasEncryptedCredentials(t *testing.T) {
+	t.Parallel()
+
+	// Case 1: legacy plaintext only -> false, nil
+	t.Run("plaintext only", func(t *testing.T) {
+		t.Parallel()
+		adapter := newTestBoltAdapter(t)
+
+		err := adapter.db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(DatabaseConfigBucket))
+			if b == nil {
+				return errors.New("bucket not found")
+			}
+			return b.Put([]byte("DBconfig:test_plain"), []byte(`{"password": "plain_password"}`))
+		})
+		if err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		hasEncrypted, err := adapter.HasEncryptedCredentials()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if hasEncrypted {
+			t.Fatalf("expected hasEncrypted to be false, got true")
+		}
+	})
+
+	// Case 2: plaintext + encrypted -> true, nil
+	t.Run("plaintext plus encrypted", func(t *testing.T) {
+		t.Parallel()
+		adapter := newTestBoltAdapter(t)
+
+		err := adapter.db.Update(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(DatabaseConfigBucket))
+			if b == nil {
+				return errors.New("bucket not found")
+			}
+			if err := b.Put([]byte("DBconfig:test_plain"), []byte(`{"password": "plain_password"}`)); err != nil {
+				return err
+			}
+			return b.Put([]byte("DBconfig:test_enc"), []byte(`{"password": "enc:v1:encrypted_password"}`))
+		})
+		if err != nil {
+			t.Fatalf("failed to insert test data: %v", err)
+		}
+
+		hasEncrypted, err := adapter.HasEncryptedCredentials()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !hasEncrypted {
+			t.Fatalf("expected hasEncrypted to be true, got false")
+		}
+	})
+
+	// Case 3: corrupt path / missing and unreadable -> false, error
+	t.Run("invalid path", func(t *testing.T) {
+		t.Parallel()
+		// Using a path that cannot be written/opened because it lies in a non-existent parent directory
+		invalidPath := filepath.Join(t.TempDir(), "nonexistent_dir", "test.bolt")
+		adapter := &BoltAdapter{dbPath: invalidPath}
+
+		hasEncrypted, err := adapter.HasEncryptedCredentials()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if hasEncrypted {
+			t.Fatalf("expected hasEncrypted to be false on error, got true")
+		}
+	})
+}

--- a/internal/adapter/storage/boltdb/bolt_adapter_test.go
+++ b/internal/adapter/storage/boltdb/bolt_adapter_test.go
@@ -1,6 +1,7 @@
 package boltdb
 
 import (
+	"OmniView/internal/adapter/security/credcipher"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -41,7 +42,17 @@ func TestBoltAdapter_HasEncryptedCredentials(t *testing.T) {
 		t.Parallel()
 		adapter := newTestBoltAdapter(t)
 
-		err := adapter.db.Update(func(tx *bolt.Tx) error {
+		cipher, err := credcipher.New(credcipher.NewFileKeyProvider(filepath.Join(t.TempDir(), "omniview.key")))
+		if err != nil {
+			t.Fatalf("credcipher.New: %v", err)
+		}
+		encrypted, err := cipher.Encrypt("encrypted_password")
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+		encryptedRow := `{"password": "` + encrypted + `"}`
+
+		err = adapter.db.Update(func(tx *bolt.Tx) error {
 			b := tx.Bucket([]byte(DatabaseConfigBucket))
 			if b == nil {
 				return errors.New("bucket not found")
@@ -49,7 +60,7 @@ func TestBoltAdapter_HasEncryptedCredentials(t *testing.T) {
 			if err := b.Put([]byte("DBconfig:test_plain"), []byte(`{"password": "plain_password"}`)); err != nil {
 				return err
 			}
-			return b.Put([]byte("DBconfig:test_enc"), []byte(`{"password": "enc:v1:encrypted_password"}`))
+			return b.Put([]byte("DBconfig:test_enc"), []byte(encryptedRow))
 		})
 		if err != nil {
 			t.Fatalf("failed to insert test data: %v", err)

--- a/internal/adapter/ui/help_overlay.go
+++ b/internal/adapter/ui/help_overlay.go
@@ -39,11 +39,13 @@ func (m *Model) renderHelpOverlay() string {
 		Align(lipgloss.Center)
 
 	// Derive subscriber procedure name — show placeholder when not yet assigned.
-	subscriberProc := "OMNI_TRACER_API.TRACE_MESSAGE_<YOUR_NAME>('msg', log_level_)"
+	subscriberProc := "Omni_Tracer_API.Trace_Message<YOUR_NAME>('msg', optional [log_level_])"
 	if m.subscriber != nil {
 		funnyName := m.subscriber.FunnyName()
 		if funnyName != "" {
-			subscriberProc = fmt.Sprintf("OMNI_TRACER_API.TRACE_MESSAGE_%s('msg', log_level_)", funnyName)
+			// Convert single-word funnyName from ALL-CAPS to PascalCase (e.g., "Chester")
+			pascalName := strings.ToUpper(funnyName[:1]) + strings.ToLower(funnyName[1:])
+			subscriberProc = fmt.Sprintf("Omni_Tracer_API.Trace_Message_%s('msg', optional [log_level_])", pascalName)
 		}
 	}
 
@@ -60,7 +62,7 @@ func (m *Model) renderHelpOverlay() string {
 		styles.SectionTitleStyle.Render("2. Global Broadcast Method"),
 		// Trace_Message is the actual mixed-case PL/SQL identifier in OMNI_TRACER_API;
 		// subscriber-specific procedures are generated all-caps (TRACE_MESSAGE_<NAME>).
-		styles.ProcedureCallStyle.Render("OMNI_TRACER_API.Trace_Message('msg', log_level_)"),
+		styles.ProcedureCallStyle.Render("Omni_Tracer_API.Trace_Message('msg', optional [log_level_])"),
 		styles.SubtitleStyle.Render("Sends to ALL connected OmniView subscribers."),
 		"",
 		styles.SectionTitleStyle.Render("3. Database Management  [D]"),

--- a/internal/adapter/ui/help_overlay_test.go
+++ b/internal/adapter/ui/help_overlay_test.go
@@ -19,7 +19,7 @@ func TestRenderHelpOverlay_ContainsSubscriberProcedureName(t *testing.T) {
 
 	overlay := m.renderHelpOverlay()
 
-	if !strings.Contains(overlay, "TRACE_MESSAGE_BARNACLE") {
+	if !strings.Contains(overlay, "Trace_Message_Barnacle") {
 		t.Fatalf("help overlay should contain subscriber procedure name, got: %s", overlay)
 	}
 }
@@ -32,7 +32,7 @@ func TestRenderHelpOverlay_WithoutSubscriberShowsPlaceholder(t *testing.T) {
 
 	overlay := m.renderHelpOverlay()
 
-	if !strings.Contains(overlay, "TRACE_MESSAGE_<YOUR_NAME>") {
+	if !strings.Contains(overlay, "Trace_Message<YOUR_NAME>") {
 		t.Fatalf("help overlay should contain placeholder when no subscriber, got: %s", overlay)
 	}
 }

--- a/internal/adapter/ui/main_screen.go
+++ b/internal/adapter/ui/main_screen.go
@@ -787,7 +787,7 @@ func (m *Model) mainProcedureCall() string {
 
 // mainFooterText: returns the footer help text showing available keyboard shortcuts.
 func (m *Model) mainFooterText() string {
-	return "↑/↓ Scroll  •  A Auto Scroll [on/off]  •  B Mode [Global/Subscriber/Broadcast]  •  C Clear  •  D Database Settings  •  H Help  •  S Settings  •  Q Quit"
+	return "↑/↓ Scroll  •  A Auto Scroll  •  B Mode  •  C Clear  •  D Database Settings  •  H Help  •  S Settings  •  Q Quit"
 }
 
 // appendSingleMessage appends only the newly-arrived message to the rendered buffer.

--- a/internal/core/domain/broadcast_mode.go
+++ b/internal/core/domain/broadcast_mode.go
@@ -13,7 +13,7 @@ type BroadcastMode int
 // ==========================================
 
 const (
-	BroadcastModeGlobal      BroadcastMode = 0
+	BroadcastModeGlobal     BroadcastMode = 0
 	BroadcastModeSubscriber BroadcastMode = 1
 	BroadcastModeBroadcast  BroadcastMode = 2
 )
@@ -28,9 +28,9 @@ func NewBroadcastMode(mode string) BroadcastMode {
 	switch mode {
 	case "Global":
 		return BroadcastModeGlobal
-	case "Subscriber":
+	case "Subscriber", "Only Subscriber":
 		return BroadcastModeSubscriber
-	case "Broadcast":
+	case "Broadcast", "Only Broadcast":
 		return BroadcastModeBroadcast
 	default:
 		return BroadcastModeGlobal
@@ -47,9 +47,9 @@ func (m BroadcastMode) String() string {
 	case BroadcastModeGlobal:
 		return "Global"
 	case BroadcastModeSubscriber:
-		return "Subscriber"
+		return "Only Subscriber"
 	case BroadcastModeBroadcast:
-		return "Broadcast"
+		return "Only Broadcast"
 	default:
 		return "Global"
 	}

--- a/internal/core/domain/broadcast_mode_test.go
+++ b/internal/core/domain/broadcast_mode_test.go
@@ -15,7 +15,9 @@ func TestNewBroadcastMode_ParsesKnownModes(t *testing.T) {
 	}{
 		{"Global", BroadcastModeGlobal},
 		{"Subscriber", BroadcastModeSubscriber},
+		{"Only Subscriber", BroadcastModeSubscriber},
 		{"Broadcast", BroadcastModeBroadcast},
+		{"Only Broadcast", BroadcastModeBroadcast},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -54,8 +56,8 @@ func TestBroadcastMode_String(t *testing.T) {
 		want string
 	}{
 		{BroadcastModeGlobal, "Global"},
-		{BroadcastModeSubscriber, "Subscriber"},
-		{BroadcastModeBroadcast, "Broadcast"},
+		{BroadcastModeSubscriber, "Only Subscriber"},
+		{BroadcastModeBroadcast, "Only Broadcast"},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -62,4 +62,7 @@ var (
 
 	// Webhook config errors
 	ErrWebhookConfigNotFound = errors.New("webhook config not found")
+
+	// Internal/Adapter sentinel errors
+	ErrEarlyAbort = errors.New("early return: encrypted credential found")
 )

--- a/internal/core/domain/queue_message_test.go
+++ b/internal/core/domain/queue_message_test.go
@@ -62,7 +62,7 @@ func TestQueueMessage_JSONRoundTrip_PreservesNonDefaultMode(t *testing.T) {
 	t.Parallel()
 
 	msg := newTestQueueMessage(t)
-	msg.mode = "Subscriber"
+	msg.mode = "Only Subscriber"
 
 	data, err := msg.MarshalJSON()
 	if err != nil {

--- a/scripts/debug.sqlnb
+++ b/scripts/debug.sqlnb
@@ -223,6 +223,9 @@ cells:
     value: SELECT name, retention FROM all_queues WHERE name = 'OMNI_TRACER_QUEUE';
     languageId: oracle-sql
   - kind: 2
+    value: ""
+    languageId: oracle-sql
+  - kind: 2
     value: |-
       SET SERVEROUTPUT ON;
       BEGIN


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR addresses two distinct concerns: refining the security/encryption key enforcement logic and making several UI label improvements.

### Security/Key Management Fix

Previously, the application would fail to start if the credential key file was missing whenever the BoltDB database file already existed—even if the database contained no encrypted credentials (e.g., legacy plaintext data). This blocked zero-friction upgrades for existing customers.

The startup logic in `cmd/omniview/main.go` now:
- Only blocks startup when the database actually contains encrypted credentials (detected via the new `HasEncryptedCredentials()` method in the BoltDB adapter, which scans for entries with the `"enc:v1:"` prefix).
- Lets database initialization proceed normally when no encrypted credentials exist, allowing a new key to be generated automatically.
- Improves the error message wording to clarify that encrypted credentials are the reason for the failure.

The new `HasEncryptedCredentials()` method handles both initialized and uninitialized adapter states, temporarily opening the database read-only when needed.

### UI Label Refinements

- **Broadcast mode names**: The broadcast mode values now display as "Only Subscriber" and "Only Broadcast" instead of "Subscriber" and "Broadcast", with backward-compatible parsing that accepts both forms.
- **Footer shortcuts**: Simplified by removing the inline `[on/off]` hint from the Auto Scroll label and condensing `[Global/Subscriber/Broadcast]` to just `Mode` in the keyboard shortcut bar.
- **PL/SQL procedure example**: The help overlay now shows the example procedure in proper mixed-case (`Omni_Tracer_API.Trace_Message_<Name>(...)`) rather than ALL-CAPS, and marks the `log_level_` parameter as optional. The subscriber's `FunnyName` is converted from ALL-CAPS to PascalCase for the example.
- **Test updates**: Corresponding unit tests for the help overlay, broadcast mode parsing, and queue message serialization were updated to reflect the new label conventions.
- **Script cleanup**: An empty SQL cell was added to the debug notebook for spacing.
<!-- kody-pr-summary:end -->