### PR TITLE
docs: display available log levels in help overlay methods

### DIFF
--- a/internal/adapter/ui/help_overlay.go
+++ b/internal/adapter/ui/help_overlay.go
@@ -19,6 +19,22 @@ const helpOverlayMaxWidth = 90
 // full inner width on wide terminals. Chosen to match the typical title line length.
 const helpOverlaySepMaxWidth = 52
 
+// logLevelLabel renders the four valid log_level_ values in their canonical
+// colors so users can match what they type with the colors in the live log.
+// Reuses the same color tokens as getLevelStyle() in main_screen.go.
+func logLevelLabel() string {
+	bold := lipgloss.NewStyle().Bold(true)
+	return styles.SubtitleStyle.Render("log_level_: ") +
+		bold.Foreground(styles.InfoColor).Render("'INFO'") +
+		styles.SubtitleStyle.Render(", ") +
+		bold.Foreground(styles.DebugColor).Render("'DEBUG'") +
+		styles.SubtitleStyle.Render(", ") +
+		bold.Foreground(styles.WarningColor).Render("'WARNING'") +
+		styles.SubtitleStyle.Render(", ") +
+		bold.Foreground(styles.ErrorColor).Render("'ERROR'") +
+		styles.SubtitleStyle.Render("  (default: INFO)")
+}
+
 // renderHelpOverlay renders the in-app help overlay panel.
 // It is displayed centered over the main screen when m.showHelp is true.
 // The subscriber's live procedure name is injected into section 1 when available.
@@ -60,12 +76,14 @@ func (m *Model) renderHelpOverlay() string {
 		"",
 		styles.SectionTitleStyle.Render("1. Subscriber-Specific Method"),
 		styles.ProcedureCallStyle.Render(subscriberProc),
+		logLevelLabel(),
 		styles.SubtitleStyle.Render("Routes the message ONLY to your OmniView instance."),
 		"",
 		styles.SectionTitleStyle.Render("2. Global Broadcast Method"),
 		// Trace_Message is the actual mixed-case PL/SQL identifier in OMNI_TRACER_API;
 		// subscriber-specific procedures are generated all-caps (TRACE_MESSAGE_<NAME>).
 		styles.ProcedureCallStyle.Render("Omni_Tracer_API.Trace_Message('msg', optional [log_level_])"),
+		logLevelLabel(),
 		styles.SubtitleStyle.Render("Sends to ALL connected OmniView subscribers."),
 		"",
 		styles.SectionTitleStyle.Render("3. Database Management  [D]"),

--- a/internal/adapter/ui/help_overlay.go
+++ b/internal/adapter/ui/help_overlay.go
@@ -19,19 +19,21 @@ const helpOverlayMaxWidth = 90
 // full inner width on wide terminals. Chosen to match the typical title line length.
 const helpOverlaySepMaxWidth = 52
 
-// logLevelLabel renders the four valid log_level_ values in their canonical
+// logLevelLabel renders the five valid log_level_ values in their canonical
 // colors so users can match what they type with the colors in the live log.
 // Reuses the same color tokens as getLevelStyle() in main_screen.go.
 func logLevelLabel() string {
-	bold := lipgloss.NewStyle().Bold(true)
+	base := styles.LogLevelStyle
 	return styles.SubtitleStyle.Render("log_level_: ") +
-		bold.Foreground(styles.InfoColor).Render("'INFO'") +
+		base.Foreground(styles.InfoColor).Render("'INFO'") +
 		styles.SubtitleStyle.Render(", ") +
-		bold.Foreground(styles.DebugColor).Render("'DEBUG'") +
+		base.Foreground(styles.DebugColor).Render("'DEBUG'") +
 		styles.SubtitleStyle.Render(", ") +
-		bold.Foreground(styles.WarningColor).Render("'WARNING'") +
+		base.Foreground(styles.WarningColor).Render("'WARNING'") +
 		styles.SubtitleStyle.Render(", ") +
-		bold.Foreground(styles.ErrorColor).Render("'ERROR'") +
+		base.Foreground(styles.ErrorColor).Render("'ERROR'") +
+		styles.SubtitleStyle.Render(", ") +
+		base.Foreground(styles.CriticalColor).Render("'CRITICAL'") +
 		styles.SubtitleStyle.Render("  (default: INFO)")
 }
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request enhances the in-app help overlay by displaying the available log level options directly within the documentation sections.

### Changes Made

1. **Added `logLevelLabel()` function**: A new helper function that renders the four valid `log_level_` values ('INFO', 'DEBUG', 'WARNING', 'ERROR') with their canonical colors, matching the color scheme used in the live log display.

2. **Integrated log level display into help overlay**: The `logLevelLabel()` output is now shown in both:
   - Section 1 (Subscriber-Specific Method)
   - Section 2 (Global Broadcast Method)

### Purpose

Users can now see the available log level options directly in the help overlay, with color-coded examples that match what appears in the live log output. This improves discoverability of the logging feature and helps users understand which values they can pass to the `log_level_` parameter.
<!-- kody-pr-summary:end -->