### PR TITLE
fix: restrict webhook delivery to messages with opt-in flag

### DIFF
--- a/internal/service/tracer/tracer_service.go
+++ b/internal/service/tracer/tracer_service.go
@@ -335,6 +335,10 @@ func (ts *TracerService) handleTracerMessage(ctx context.Context, msg *domain.Qu
 		logger.Info("event channel unavailable, emitting via structured logger", "msg", msg.Format())
 	}
 
+	if !msg.SendToWebhook() {
+		return true
+	}
+
 	// Dispatch to webhook if configured
 	webhookConfig, err := ts.bolt.GetWebhookConfig()
 	if err != nil || webhookConfig == nil || webhookConfig.URL == "" {

--- a/internal/service/tracer/tracer_service_test.go
+++ b/internal/service/tracer/tracer_service_test.go
@@ -11,28 +11,28 @@ import (
 
 type stubConfigRepository struct{}
 
-func (stubConfigRepository) SaveDatabaseConfig(*domain.DatabaseSettings) error { return nil }
-func (stubConfigRepository) GetDefaultDatabaseConfig() (*domain.DatabaseSettings, error) {
+func (r *stubConfigRepository) SaveDatabaseConfig(*domain.DatabaseSettings) error { return nil }
+func (r *stubConfigRepository) GetDefaultDatabaseConfig() (*domain.DatabaseSettings, error) {
 	return nil, nil
 }
-func (stubConfigRepository) IsApplicationFirstRun() (bool, error)               { return false, nil }
-func (stubConfigRepository) SetFirstRunCycleStatus(domain.RunCycleStatus) error { return nil }
-func (stubConfigRepository) SaveWebhookConfig(*domain.WebhookConfig) error      { return nil }
-func (stubConfigRepository) GetWebhookConfig() (*domain.WebhookConfig, error)   { return nil, nil }
-func (stubConfigRepository) DeleteWebhookConfig(string) error                   { return nil }
-func (stubConfigRepository) GetTracerPackageVersion() (string, error)           { return "", nil }
-func (stubConfigRepository) SetTracerPackageVersion(string) error               { return nil }
-func (stubConfigRepository) GetBroadcastMode() (domain.BroadcastMode, error) {
+func (r *stubConfigRepository) IsApplicationFirstRun() (bool, error)               { return false, nil }
+func (r *stubConfigRepository) SetFirstRunCycleStatus(domain.RunCycleStatus) error { return nil }
+func (r *stubConfigRepository) SaveWebhookConfig(*domain.WebhookConfig) error      { return nil }
+func (r *stubConfigRepository) GetWebhookConfig() (*domain.WebhookConfig, error)   { return nil, nil }
+func (r *stubConfigRepository) DeleteWebhookConfig(string) error                   { return nil }
+func (r *stubConfigRepository) GetTracerPackageVersion() (string, error)           { return "", nil }
+func (r *stubConfigRepository) SetTracerPackageVersion(string) error               { return nil }
+func (r *stubConfigRepository) GetBroadcastMode() (domain.BroadcastMode, error) {
 	return domain.BroadcastModeGlobal, nil
 }
-func (stubConfigRepository) SetBroadcastMode(domain.BroadcastMode) error { return nil }
+func (r *stubConfigRepository) SetBroadcastMode(domain.BroadcastMode) error { return nil }
 
 type webhookConfigRepository struct {
 	stubConfigRepository
 	config *domain.WebhookConfig
 }
 
-func (r webhookConfigRepository) GetWebhookConfig() (*domain.WebhookConfig, error) {
+func (r *webhookConfigRepository) GetWebhookConfig() (*domain.WebhookConfig, error) {
 	return r.config, nil
 }
 
@@ -72,7 +72,7 @@ func (stubDatabaseRepository) DeployFile(context.Context, string) error { return
 func TestNewTracerService_RejectsNilDependencies(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewTracerService(nil, stubConfigRepository{}, make(chan *domain.QueueMessage, 1))
+	_, err := NewTracerService(nil, &stubConfigRepository{}, make(chan *domain.QueueMessage, 1))
 	if !errors.Is(err, domain.ErrNilRepository) {
 		t.Fatalf("expected ErrNilRepository, got %v", err)
 	}
@@ -292,7 +292,7 @@ func TestHandleTracerMessage_QueuesWebhookOnlyWithOptIn(t *testing.T) {
 				t.Fatalf("failed to create queue message: %v", err)
 			}
 
-			ts := &TracerService{bolt: webhookConfigRepository{config: config}}
+			ts := &TracerService{bolt: &webhookConfigRepository{config: config}}
 			if ok := ts.handleTracerMessage(context.Background(), msg); !ok {
 				t.Fatal("expected handleTracerMessage to continue processing")
 			}

--- a/internal/service/tracer/tracer_service_test.go
+++ b/internal/service/tracer/tracer_service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 )
 
 type stubConfigRepository struct{}
@@ -25,6 +26,15 @@ func (stubConfigRepository) GetBroadcastMode() (domain.BroadcastMode, error) {
 	return domain.BroadcastModeGlobal, nil
 }
 func (stubConfigRepository) SetBroadcastMode(domain.BroadcastMode) error { return nil }
+
+type webhookConfigRepository struct {
+	stubConfigRepository
+	config *domain.WebhookConfig
+}
+
+func (r webhookConfigRepository) GetWebhookConfig() (*domain.WebhookConfig, error) {
+	return r.config, nil
+}
 
 type stubDatabaseRepository struct{}
 
@@ -242,5 +252,54 @@ func TestCancelConnectionListener_ContinuesOnUnregisterError(t *testing.T) {
 	}
 	if ts.activeSubscriber != nil {
 		t.Fatal("expected activeSubscriber to be cleared even after unregistration error")
+	}
+}
+
+func TestHandleTracerMessage_QueuesWebhookOnlyWithOptIn(t *testing.T) {
+	previousDispatcher := globalWebhookDispatcher
+
+	t.Cleanup(func() {
+		globalWebhookDispatcher = previousDispatcher
+		dispatcherOnce = sync.Once{}
+	})
+
+	config, err := domain.NewWebhookConfig(domain.DefaultWebhookID, "https://example.com/webhook", true)
+	if err != nil {
+		t.Fatalf("failed to create webhook config: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name          string
+		sendToWebhook bool
+		wantQueued    int
+	}{
+		{name: "without opt-in", sendToWebhook: false, wantQueued: 0},
+		{name: "with opt-in", sendToWebhook: true, wantQueued: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			globalWebhookDispatcher = &webhookDispatcher{queue: make(chan webhookJob, 1)}
+			dispatcherOnce = sync.Once{}
+
+			msg, err := domain.NewQueueMessage(
+				"message",
+				"TEST_PROCESS",
+				domain.LogLevelInfo,
+				"payload",
+				time.Unix(1700000000, 0),
+				tt.sendToWebhook,
+			)
+			if err != nil {
+				t.Fatalf("failed to create queue message: %v", err)
+			}
+
+			ts := &TracerService{bolt: webhookConfigRepository{config: config}}
+			if ok := ts.handleTracerMessage(context.Background(), msg); !ok {
+				t.Fatal("expected handleTracerMessage to continue processing")
+			}
+
+			if queued := len(globalWebhookDispatcher.queue); queued != tt.wantQueued {
+				t.Fatalf("expected %d webhook jobs to be queued, got %d", tt.wantQueued, queued)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request fixes an issue where webhook delivery was not respecting the opt-in flag on messages. The changes ensure that only messages with the explicit `SendToWebhook` flag set to `true` are dispatched to webhooks.

## Changes Made

1. **tracer_service.go**: Added an early return check in the `handleTracerMessage` function to skip webhook dispatch entirely when the message does not have the opt-in flag set (`!msg.SendToWebhook()`).

2. **tracer_service_test.go**: Added a new test case `TestHandleTracerMessage_QueuesWebhookOnlyWithOptIn` that verifies:
   - Messages **without** opt-in flag: No webhook job is queued
   - Messages **with** opt-in flag: Webhook job is queued as expected

## Impact

This fix ensures webhook delivery is properly gated by the opt-in flag, preventing unintended webhook dispatches for messages that have not explicitly requested webhook delivery.
<!-- kody-pr-summary:end -->