### PR TITLE
fix: ensure webhook dispatcher is injected for testing

### DIFF
--- a/internal/service/tracer/tracer_service_test.go
+++ b/internal/service/tracer/tracer_service_test.go
@@ -277,8 +277,10 @@ func TestHandleTracerMessage_QueuesWebhookOnlyWithOptIn(t *testing.T) {
 		{name: "with opt-in", sendToWebhook: true, wantQueued: 1},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			globalWebhookDispatcher = &webhookDispatcher{queue: make(chan webhookJob, 1)}
+			injectedDispatcher := &webhookDispatcher{queue: make(chan webhookJob, 1)}
+			globalWebhookDispatcher = injectedDispatcher
 			dispatcherOnce = sync.Once{}
+			dispatcherOnce.Do(func() {})
 
 			msg, err := domain.NewQueueMessage(
 				"message",
@@ -297,7 +299,7 @@ func TestHandleTracerMessage_QueuesWebhookOnlyWithOptIn(t *testing.T) {
 				t.Fatal("expected handleTracerMessage to continue processing")
 			}
 
-			if queued := len(globalWebhookDispatcher.queue); queued != tt.wantQueued {
+			if queued := len(injectedDispatcher.queue); queued != tt.wantQueued {
 				t.Fatalf("expected %d webhook jobs to be queued, got %d", tt.wantQueued, queued)
 			}
 		})

--- a/internal/service/tracer/tracer_service_test.go
+++ b/internal/service/tracer/tracer_service_test.go
@@ -280,6 +280,8 @@ func TestHandleTracerMessage_QueuesWebhookOnlyWithOptIn(t *testing.T) {
 			injectedDispatcher := &webhookDispatcher{queue: make(chan webhookJob, 1)}
 			globalWebhookDispatcher = injectedDispatcher
 			dispatcherOnce = sync.Once{}
+			// Mark sync.Once as used so getWebhookDispatcher keeps the injected dispatcher
+			// instead of replacing it with a real worker-backed dispatcher.
 			dispatcherOnce.Do(func() {})
 
 			msg, err := domain.NewQueueMessage(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request fixes a test isolation issue in the tracer service tests. The changes ensure that the webhook dispatcher is properly injected and reset for each test case, preventing state leakage between tests.

### Changes Made

1. **Captures the dispatcher reference**: The test now stores the injected dispatcher in a local variable (`injectedDispatcher`) before assigning it to the global, making the test more explicit about which dispatcher instance it's checking.

2. **Resets the sync.Once state**: Added `dispatcherOnce.Do(func() {})` to properly trigger/reset the `sync.Once` mechanism, ensuring the singleton pattern doesn't retain state from previous test runs.

3. **Uses the captured reference for assertions**: The test now checks the length of `injectedDispatcher.queue` instead of `globalWebhookDispatcher.queue`, ensuring we're inspecting the exact dispatcher instance that was set up for this specific test.

### Why This Matters

These changes address test flakiness that could occur when tests run in parallel or sequentially, where the webhook dispatcher singleton might retain state from previous test executions, causing inconsistent test results.
<!-- kody-pr-summary:end -->