### PR TITLE
Feature/basuruk/header logo placement

### DIFF
--- a/internal/adapter/ui/main_screen.go
+++ b/internal/adapter/ui/main_screen.go
@@ -31,7 +31,16 @@ const (
 	mainGapAfterHeader  = 1
 	mainGapAfterStatus  = 0
 	mainGapAfterPanel   = 0
+	mainLogoMinGap      = 5
+	mainLogoMinWidth    = 40
 )
+
+var mainCornerLogoASCII = strings.Join([]string{
+	"               _     _",
+	" ___ _____ ___|_|_ _|_|___ _ _ _",
+	"| . |     |   | | | | | -_| | | |",
+	"|___|_|_|_|_|_|_|\\_/|_|___|_____|",
+}, "\n")
 
 // ==========================================
 // Trace Column Definitions
@@ -271,6 +280,7 @@ func (m *Model) computeMainLayout() mainLayoutParts {
 		m.mainProcedureCall(),
 		m.mainConnectionMeta(),
 	)
+	header = renderMainHeaderWithLogo(contentWidth, header)
 	statusBar := renderInfoBar(contentWidth, m.mainStatusText())
 	footer := renderFooterBar(contentWidth, m.mainFooterText())
 
@@ -296,6 +306,21 @@ func (m *Model) computeMainLayout() mainLayoutParts {
 		viewportWidth:  viewportWidth,
 		viewportHeight: viewportHeight,
 	}
+}
+
+func renderMainHeaderWithLogo(width int, header string) string {
+	if width < mainLogoMinWidth {
+		return header
+	}
+
+	logo := styles.LogoSubtleStyle.Bold(true).Render(mainCornerLogoASCII)
+	logoWidth := lipgloss.Width(logo)
+	if width < logoWidth+mainLogoMinGap {
+		return header
+	}
+
+	left := lipgloss.NewStyle().Width(max(width-logoWidth, 1)).Render(header)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, logo)
 }
 
 // repeatSectionGaps

--- a/internal/adapter/ui/main_screen.go
+++ b/internal/adapter/ui/main_screen.go
@@ -28,7 +28,7 @@ const (
 	maxMessages         = 10000
 	maxRawBytes         = 100 * 1024 * 1024
 	maxProcessNameWidth = 20
-	mainGapAfterHeader  = 1
+	mainGapAfterHeader  = 0
 	mainGapAfterStatus  = 0
 	mainGapAfterPanel   = 0
 	mainLogoMinGap      = 5
@@ -36,8 +36,7 @@ const (
 )
 
 var mainCornerLogoASCII = strings.Join([]string{
-	"               _     _",
-	" ___ _____ ___|_|_ _|_|___ _ _ _",
+	" ___ _____ ___|*|_ _|*|___ _ _ _",
 	"| . |     |   | | | | | -_| | | |",
 	"|___|_|_|_|_|_|_|\\_/|_|___|_____|",
 }, "\n")
@@ -320,7 +319,8 @@ func renderMainHeaderWithLogo(width int, header string) string {
 	}
 
 	left := lipgloss.NewStyle().Width(max(width-logoWidth, 1)).Render(header)
-	return lipgloss.JoinHorizontal(lipgloss.Top, left, logo)
+	joined := lipgloss.JoinHorizontal(lipgloss.Bottom, left, logo)
+	return joined
 }
 
 // repeatSectionGaps

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -38,7 +38,8 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	if !strings.Contains(plainHeader, "Omni_Tracer_API.Trace_Message_Barnacle('msg')") {
 		t.Fatalf("header should contain procedure call, got: %s", layout.header)
 	}
-	if strings.Contains(layout.statusBar, "TRACE_MESSAGE_") {
+	plainStatusBar := stripANSIForTest(layout.statusBar)
+	if strings.Contains(plainStatusBar, "TRACE_MESSAGE_") {
 		t.Fatalf("status bar should not contain procedure call, got: %s", layout.statusBar)
 	}
 

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,12 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 )
+
+var ansiEscapePatternForTest = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+func stripANSIForTest(value string) string {
+	return ansiEscapePatternForTest.ReplaceAllString(value, "")
+}
 
 // ==========================================
 // Procedure Call Display Tests
@@ -97,6 +104,36 @@ func TestMainViewWithProcedureCallStaysWithinTerminalAtNarrowWidth(t *testing.T)
 	rendered := m.viewMain()
 
 	assertRenderedWithinTerminal(t, rendered, m.width, m.height)
+}
+
+func TestComputeMainLayout_IncludesTopRightLogoOnWideScreens(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMainModel(t, 120, 36)
+	layout := m.computeMainLayout()
+	expectedLogo := mainCornerLogoASCII
+	plainHeader := stripANSIForTest(layout.header)
+
+	for _, logoLine := range strings.Split(expectedLogo, "\n") {
+		if !strings.Contains(plainHeader, logoLine) {
+			t.Fatalf("expected header to include ASCII logo line %q, got: %s", logoLine, layout.header)
+		}
+	}
+}
+
+func TestComputeMainLayout_HidesTopRightLogoOnNarrowScreens(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMainModel(t, 12, 24)
+	layout := m.computeMainLayout()
+	expectedLogo := mainCornerLogoASCII
+	plainHeader := stripANSIForTest(layout.header)
+
+	for _, logoLine := range strings.Split(expectedLogo, "\n") {
+		if strings.Contains(plainHeader, logoLine) {
+			t.Fatalf("expected header logo to be hidden on narrow screens, got: %s", layout.header)
+		}
+	}
 }
 
 // ==========================================

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -33,8 +33,9 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	m.subscriber = mustNewTestSubscriberWithFunnyName(t, "SUB_TEST", "BARNACLE")
 
 	layout := m.computeMainLayout()
+	plainHeader := stripANSIForTest(layout.header)
 
-	if !strings.Contains(layout.header, "Omni_Tracer_API.Trace_Message_Barnacle('msg')") {
+	if !strings.Contains(plainHeader, "Omni_Tracer_API.Trace_Message_Barnacle('msg')") {
 		t.Fatalf("header should contain procedure call, got: %s", layout.header)
 	}
 	if strings.Contains(layout.statusBar, "TRACE_MESSAGE_") {
@@ -45,7 +46,7 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	// line immediately below the database name line instead of being on the
 	// same line. Either arrangement is acceptable as long as the procedure
 	// call appears in the header, close to the database name.
-	headerLines := strings.Split(layout.header, "\n")
+	headerLines := strings.Split(plainHeader, "\n")
 	dbLineIdx := -1
 	procLineIdx := -1
 	for i, line := range headerLines {

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -40,15 +40,31 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	if strings.Contains(layout.statusBar, "TRACE_MESSAGE_") {
 		t.Fatalf("status bar should not contain procedure call, got: %s", layout.statusBar)
 	}
-	found := false
-	for _, line := range strings.Split(layout.header, "\n") {
-		if strings.Contains(line, "QA_DB") && strings.Contains(line, "Omni_Tracer_API.Trace_Message_Barnacle('msg')") {
-			found = true
-			break
+
+	// With the logo in the top-right corner, the procedure call may wrap to a
+	// line immediately below the database name line instead of being on the
+	// same line. Either arrangement is acceptable as long as the procedure
+	// call appears in the header, close to the database name.
+	headerLines := strings.Split(layout.header, "\n")
+	dbLineIdx := -1
+	procLineIdx := -1
+	for i, line := range headerLines {
+		if dbLineIdx == -1 && strings.Contains(line, "QA_DB") {
+			dbLineIdx = i
+		}
+		if procLineIdx == -1 && strings.Contains(line, "Omni_Tracer_API.Trace_Message_Barnacle('msg')") {
+			procLineIdx = i
 		}
 	}
-	if !found {
-		t.Fatalf("header should place procedure call next to database name, got: %s", layout.header)
+	if dbLineIdx == -1 {
+		t.Fatalf("header should contain database name, got: %s", layout.header)
+	}
+	if procLineIdx == -1 {
+		t.Fatalf("header should contain procedure call, got: %s", layout.header)
+	}
+	// Procedure call should be on the same line or the line immediately after the database name.
+	if procLineIdx != dbLineIdx && procLineIdx != dbLineIdx+1 {
+		t.Fatalf("procedure call should be near database name (same line or next line), got dbLine=%d procLine=%d. Header:\n%s", dbLineIdx, procLineIdx, layout.header)
 	}
 }
 

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -136,6 +136,57 @@ func TestComputeMainLayout_HidesTopRightLogoOnNarrowScreens(t *testing.T) {
 	}
 }
 
+func TestComputeMainLayout_StatusBarFollowsHeaderWithNoGap(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMainModel(t, 120, 36)
+
+	// The layout calculation reserves mainGapAfterHeader blank spacer lines
+	// between the header and the status bar. With it set to 0, the status bar
+	// should immediately follow the header with no blank line between them.
+	// We verify this by checking that the status bar's top border line appears
+	// on the line right after the header's last content line, with no blank
+	// spacer in between.
+	m.initViewport()
+	rendered := m.viewMain()
+	plainRendered := stripANSIForTest(rendered)
+	allLines := strings.Split(plainRendered, "\n")
+
+	// Find the last line of the header (the line containing the subtitle text)
+	// and the first line of the status bar (the top border ╭─...─╮).
+	headerLastIdx := -1
+	statusBarFirstIdx := -1
+	for i, line := range allLines {
+		if strings.Contains(line, "Live Oracle trace viewer") {
+			headerLastIdx = i
+		}
+		if statusBarFirstIdx == -1 && strings.HasPrefix(strings.TrimSpace(line), "╭") {
+			statusBarFirstIdx = i
+		}
+	}
+
+	if headerLastIdx == -1 {
+		t.Fatalf("expected to find header subtitle line in rendered view")
+	}
+	if statusBarFirstIdx == -1 {
+		t.Fatalf("expected to find status bar top border in rendered view")
+	}
+
+	// With mainGapAfterHeader=0, the status bar's top border should be on the
+	// line immediately after the header's last line. If there's a gap, there
+	// will be a blank line between them.
+	if statusBarFirstIdx-headerLastIdx != 1 {
+		t.Fatalf("expected status bar to follow header directly (gap of 1), got gap of %d. headerLast=%d statusBarFirst=%d. Rendered:\n%s",
+			statusBarFirstIdx-headerLastIdx, headerLastIdx, statusBarFirstIdx, plainRendered)
+	}
+
+	// Also verify the line between them is not blank
+	betweenLine := allLines[headerLastIdx+1]
+	if betweenLine != allLines[statusBarFirstIdx] {
+		t.Fatalf("expected line between header and status bar to be the status bar itself")
+	}
+}
+
 // ==========================================
 // Helper Functions
 // ==========================================


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented:

1. **Main Changes to `internal/adapter/ui/main_screen.go`:**
   - Changed `mainGapAfterHeader` from `1` to `0` - removes the gap between header and status bar
   - Added two new constants: `mainLogoMinGap` (5) and `mainLogoMinWidth` (40)
   - Added a new ASCII art logo string `mainCornerLogoASCII` - a stylized "OmniInspect" text logo
   - Modified `computeMainLayout()` to call a new function `renderMainHeaderWithLogo()` before rendering the status bar
   - Added new function `renderMainHeaderWithLogo(width int, header string) string` that:
     - Returns the header unchanged if width < `mainLogoMinWidth` (40)
     - Renders the ASCII logo if width >= `mainLogoMinWidth`
     - Joins the logo to the right side of the header horizontally
     - Returns header unchanged if width < logoWidth + mainLogoMinGap

2. **Test Changes to `internal/adapter/ui/main_screen_test.go`:**
   - Added ANSI escape pattern helper for stripping colors from test assertions
   - Modified existing test `TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader` to be more flexible about where the procedure call appears in the header (now allows it to be on the same line OR the line immediately after the database name)
   - Added new test `TestComputeMainLayout_IncludesTopRightLogoOnWideScreens` - verifies the logo appears on screens >= 120 chars wide
   - Added new test `TestComputeMainLayout_HidesTopRightLogoOnNarrowScreens` - verifies the logo is hidden on narrow screens (< 40 chars)
   - Added new test `TestComputeMainLayout_StatusBarFollowsHeaderWithNoGap` - verifies the status bar immediately follows the header with no blank line when `mainGapAfterHeader=0`

The implementation adds a decorative OmniInspect ASCII logo to the top-right corner of the main screen header, displayed only when screen width meets the minimum threshold of 40 characters. The logo appears on wider displays (120+ chars) but remains hidden on narrow terminals. A new test confirms the status bar renders directly adjacent to the header without any spacing.
</think>

## Summary

This pull request adds an OmniInspect ASCII art logo to the top-right corner of the main screen header, displayed only on wider terminals, along with related test coverage and a minor layout adjustment.

### Key Changes

1. **ASCII Logo Rendering**: Introduced a 3-line ASCII art logo ("OmniInspect") that appears in the top-right corner of the header on terminals wide enough to accommodate it.

2. **Responsive Logo Display**: The logo is conditionally rendered based on terminal width:
   - Hidden when width < 40 characters (min width threshold)
   - Hidden when width < logo width + 5 characters (min gap threshold)
   - Displayed on wider terminals by joining it horizontally to the right of the header content

3. **Removed Header Gap**: Changed `mainGapAfterHeader` from 1 to 0, eliminating the blank spacer line between the header and status bar so the status bar immediately follows the header.

4. **Updated Test Assertions**: Modified the existing procedure call header test to accept both same-line and line-immediately-after arrangements for the procedure call within the header (accommodating the new logo placement).

5. **New Test Coverage**: Added tests verifying:
   - Logo presence on wide screens (120+ width)
   - Logo absence on narrow screens (< 40 width)
   - Status bar directly follows header with no gap
<!-- kody-pr-summary:end -->