### PR TITLE
feat(ui): show MCP server status next to procedure call in header

### DIFF
--- a/cmd/omniview/main.go
+++ b/cmd/omniview/main.go
@@ -104,8 +104,10 @@ func run(omniApp *app.App) error {
 
 	// Auto-start the MCP server so agents can drive OmniView without a separate `omniview mcp` invocation. It serves over HTTP rather than stdio here, since the TUI already owns stdin/stdout in this process. Only one instance can bind mcpListenAddr, so a second launch silently loses MCP rather than double-serving.
 	stopMCP, err := startMCPServer(omniApp, boltAdapter, traceAppender, dbSettingsRepo)
+	mcpActive := false
 	if stopMCP != nil {
 		defer stopMCP()
+		mcpActive = true
 	}
 	if err != nil {
 		logger.Warn("MCP server disabled", "error", err)
@@ -125,6 +127,8 @@ func run(omniApp *app.App) error {
 		EventChannel:   eventCh,
 		UpdaterService: updaterService,
 		TraceAppender:  traceAppender,
+		MCPActive:      mcpActive,
+		MCPAddr:        mcpListenAddr,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create UI model: %w", err)

--- a/internal/adapter/ui/main_screen.go
+++ b/internal/adapter/ui/main_screen.go
@@ -310,7 +310,7 @@ func (m *Model) computeMainLayout() mainLayoutParts {
 		contentWidth,
 		"OmniView Trace Console",
 		m.mainSubtitle(),
-		m.mainProcedureCall(),
+		m.mainHeaderDetail(),
 		m.mainConnectionMeta(),
 	)
 	header = renderMainHeaderWithLogo(contentWidth, header)
@@ -850,6 +850,7 @@ func (m *Model) mainStatusText() string {
 	)
 }
 
+// mainProcedureCall returns the procedure call for the main header detail line.
 func (m *Model) mainProcedureCall() string {
 	if m.subscriber == nil {
 		return ""
@@ -865,6 +866,48 @@ func (m *Model) mainProcedureCall() string {
 	return styles.ProcedureCallStyle.Render(
 		fmt.Sprintf("Omni_Tracer_API.Trace_Message_%s('msg')", funnyName),
 	)
+}
+
+// mainMCPStatus returns the MCP listen status for the main header detail line.
+// Only the active/inactive token is colored; the surrounding label uses the muted header style.
+func (m *Model) mainMCPStatus() string {
+	if strings.TrimSpace(m.mcpAddr) == "" {
+		return ""
+	}
+
+	status := "inactive"
+	statusColor := styles.ErrorColor
+	if m.mcpActive {
+		status = "active"
+		statusColor = styles.SuccessColor
+	}
+
+	muted := styles.HeaderSubtitleStyle
+	statusStyle := lipgloss.NewStyle().Foreground(statusColor).Bold(true)
+	return lipgloss.JoinHorizontal(
+		lipgloss.Center,
+		muted.Render("MCP ["),
+		statusStyle.Render(status),
+		muted.Render(fmt.Sprintf("] : %s", m.mcpAddr)),
+	)
+}
+
+// mainHeaderDetail joins the procedure call and MCP status for the header subtitle line.
+func (m *Model) mainHeaderDetail() string {
+	parts := make([]string, 0, 3)
+	if proc := m.mainProcedureCall(); proc != "" {
+		parts = append(parts, proc)
+	}
+	if mcp := m.mainMCPStatus(); mcp != "" {
+		if len(parts) > 0 {
+			parts = append(parts, styles.HeaderSubtitleStyle.Render("  •  "))
+		}
+		parts = append(parts, mcp)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Center, parts...)
 }
 
 // mainFooterText: returns the footer help text showing available keyboard shortcuts.

--- a/internal/adapter/ui/main_screen_test.go
+++ b/internal/adapter/ui/main_screen_test.go
@@ -70,6 +70,46 @@ func TestComputeMainLayout_WithFunnyNameRendersProcedureCallInHeader(t *testing.
 	}
 }
 
+func TestComputeMainLayout_WithMCPActiveRendersStatusNextToProcedureCall(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMainModel(t, 140, 36)
+	m.appConfig = mustNewTestDatabaseSettings(t, "QA_DB")
+	m.subscriber = mustNewTestSubscriberWithFunnyName(t, "SUB_TEST", "BARNACLE")
+	m.mcpActive = true
+	m.mcpAddr = "127.0.0.1:54332"
+
+	layout := m.computeMainLayout()
+	plainHeader := stripANSIForTest(layout.header)
+	// Logo can wrap the address onto the next line, so assert the pieces separately.
+	compactHeader := strings.ReplaceAll(plainHeader, "\n", "")
+
+	if !strings.Contains(plainHeader, "Omni_Tracer_API.Trace_Message_Barnacle('msg')") {
+		t.Fatalf("header should contain procedure call, got: %s", plainHeader)
+	}
+	if !strings.Contains(compactHeader, "MCP [active]") {
+		t.Fatalf("header should contain active MCP status, got: %s", plainHeader)
+	}
+	if !strings.Contains(compactHeader, "127.0.0.1:54332") {
+		t.Fatalf("header should contain MCP listen addr, got: %s", plainHeader)
+	}
+}
+
+func TestComputeMainLayout_WithMCPInactiveRendersInactiveStatus(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMainModel(t, 140, 36)
+	m.mcpActive = false
+	m.mcpAddr = "127.0.0.1:54332"
+
+	layout := m.computeMainLayout()
+	plainHeader := stripANSIForTest(layout.header)
+
+	if !strings.Contains(plainHeader, "MCP [inactive] : 127.0.0.1:54332") {
+		t.Fatalf("header should contain inactive MCP status, got: %s", plainHeader)
+	}
+}
+
 func TestComputeMainLayout_WithoutFunnyNameOmitsProcedureCall(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/ui/model.go
+++ b/internal/adapter/ui/model.go
@@ -179,6 +179,10 @@ type Model struct {
 	easterEggOmega1 float64    // inner angular velocity
 	easterEggOmega2 float64    // outer angular velocity
 	easterEggTrace  []eggPoint // recent outer-bob positions, oldest first
+
+	// MCP server status shown in the main header next to the procedure call.
+	mcpActive bool
+	mcpAddr   string
 }
 
 // ModelOpts holds the dependencies injected into the Model
@@ -196,6 +200,8 @@ type ModelOpts struct {
 	EventChannel       chan *domain.QueueMessage
 	UpdateEventChannel chan tea.Msg        // Optional - can be created by Model if not provided
 	TraceAppender      ports.TraceAppender // Optional — shared buffer for non-UI consumers (MCP server, tests)
+	MCPActive          bool                // Optional — whether the in-process MCP server is listening
+	MCPAddr            string              // Optional — MCP listen address (e.g. 127.0.0.1:54332)
 }
 
 func NewModel(opts ModelOpts) (*Model, error) {
@@ -259,6 +265,8 @@ func NewModel(opts ModelOpts) (*Model, error) {
 		appConfig:          opts.AppConfig,
 		eventChannel:       eventChannel,
 		updateEventChannel: updateEventChannel,
+		mcpActive:          opts.MCPActive,
+		mcpAddr:            opts.MCPAddr,
 		loading: loadingState{
 			spinner: s,
 		},


### PR DESCRIPTION
Surface whether the in-process MCP server is listening so operators can see active/inactive state and the loopback address without leaving the TUI.