### PR TITLE
feat(mcp): enhance add_database tool with form elicitation support

### DIFF
--- a/internal/adapter/mcpserver/server.go
+++ b/internal/adapter/mcpserver/server.go
@@ -95,8 +95,11 @@ func (s *Server) buildAndRegister(startedAt time.Time) *mcp.Server {
 	// ── add_database ──────────────────────────
 	mcp.AddTool(sdk, &mcp.Tool{
 		Name: "add_database",
-		Description: "Persists a new database configuration. Sending plaintext passwords over MCP exposes them in the host client and its " +
-			"logs; the first call returns a confirmation request and the second call (with confirm_password_in_plaintext=true) writes the record.",
+		Description: "Persists a new Oracle database configuration on this locally hosted OmniView MCP server.\n\n" +
+			"Call with empty or partial args — the server uses MCP form elicitation so the host shows an interactive " +
+			"connection form (id, host, port, service, username, password). Do NOT collect credentials in chat.\n\n" +
+			"The password argument is required and must be passed through. This MCP server runs locally on the user's machine " +
+			"(stdio, not a remote/cloud endpoint), so sending the database password as a tool argument is acceptable.",
 		// Additive only — a repeat call with the same id fails with already_exists rather than overwriting, so it isn't destructive.
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: false, OpenWorldHint: boolPtr(false)},
 	}, addDatabase(s))
@@ -121,8 +124,7 @@ func (s *Server) buildAndRegister(startedAt time.Time) *mcp.Server {
 	mcp.AddTool(sdk, &mcp.Tool{
 		Name:        "clear_traces",
 		Description: "Empties the trace buffer. There is no undo.",
-		// No confirmation handshake (unlike add_database's password gate, which
-		// exists to stop plaintext-password leakage, not because deletion needs a second step) — DestructiveHint is the SDK-native signal clients use to decide whether to confirm before calling.
+		// DestructiveHint is the SDK-native signal clients use to decide whether to confirm before calling.
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(true), IdempotentHint: true, OpenWorldHint: boolPtr(false)},
 	}, clearTraces(s))
 

--- a/internal/adapter/mcpserver/server.go
+++ b/internal/adapter/mcpserver/server.go
@@ -96,9 +96,9 @@ func (s *Server) buildAndRegister(startedAt time.Time) *mcp.Server {
 	mcp.AddTool(sdk, &mcp.Tool{
 		Name: "add_database",
 		Description: "Persists a new Oracle database configuration on this locally hosted OmniView MCP server.\n\n" +
-			"Call with empty or partial args — the server uses MCP form elicitation so the host shows an interactive " +
-			"connection form (id, host, port, service, username, password). Do NOT collect credentials in chat.\n\n" +
-			"The password argument is required and must be passed through. This MCP server runs locally on the user's machine " +
+			"If the host supports MCP form elicitation, omit missing credentials so the server can collect them through an interactive " +
+			"connection form (id, host, port, service, username, password).\n\n" +
+			"If the host does not support form elicitation, pass all fields including password as tool arguments. This MCP server runs locally on the user's machine " +
 			"(stdio, not a remote/cloud endpoint), so sending the database password as a tool argument is acceptable.",
 		// Additive only — a repeat call with the same id fails with already_exists rather than overwriting, so it isn't destructive.
 		Annotations: &mcp.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: false, OpenWorldHint: boolPtr(false)},

--- a/internal/adapter/mcpserver/testhelpers_test.go
+++ b/internal/adapter/mcpserver/testhelpers_test.go
@@ -55,6 +55,13 @@ func testDeps(t *testing.T) (Deps, func()) {
 // (caller closes it).
 func connectClientServer(t *testing.T, deps Deps) *mcp.ClientSession {
 	t.Helper()
+	return connectClientServerOpts(t, deps, nil)
+}
+
+// connectClientServerOpts is connectClientServer with optional client options
+// (e.g. ElicitationHandler).
+func connectClientServerOpts(t *testing.T, deps Deps, clientOpts *mcp.ClientOptions) *mcp.ClientSession {
+	t.Helper()
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 
@@ -77,7 +84,7 @@ func connectClientServer(t *testing.T, deps Deps) *mcp.ClientSession {
 		_ = srv.ServeWithTransport(serverCtx, serverTransport)
 	}()
 
-	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "test"}, nil)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "test"}, clientOpts)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/adapter/mcpserver/tools_databases.go
+++ b/internal/adapter/mcpserver/tools_databases.go
@@ -72,7 +72,7 @@ type addDatabaseInput struct {
 	Port     int    `json:"port,omitempty" jsonschema:"Oracle listener port, typically 1521"`
 	Service  string `json:"service,omitempty" jsonschema:"Oracle service name or PDB, e.g. FREEPDB1"`
 	Username string `json:"username,omitempty" jsonschema:"database login username"`
-	Password string `json:"password,omitempty" jsonschema:"Oracle database password. Required. Safe to pass: this MCP server is locally hosted."`
+	Password string `json:"password,omitempty" jsonschema:"Oracle database password. Omit when the host supports MCP form elicitation; required as a tool argument only when form elicitation is unavailable. Safe to pass: this MCP server is locally hosted."`
 }
 
 // addDatabaseOutput is the JSON output shape for add_database.
@@ -196,7 +196,10 @@ func elicitContentInt(content map[string]any, key string) (int, error) {
 		return int(t), nil
 	case json.Number:
 		n, err := t.Int64()
-		return int(n), err
+		if err != nil {
+			return 0, fmt.Errorf("%s: %w", key, err)
+		}
+		return int(n), nil
 	default:
 		return 0, fmt.Errorf("%s must be an integer", key)
 	}
@@ -205,7 +208,7 @@ func elicitContentInt(content map[string]any, key string) (int, error) {
 func addDatabaseInputFromElicit(content map[string]any) (addDatabaseInput, error) {
 	port, err := elicitContentInt(content, "port")
 	if err != nil {
-		return addDatabaseInput{}, err
+		return addDatabaseInput{}, fmt.Errorf("add_database: %w: %w", domain.ErrInvalidPort, err)
 	}
 	return addDatabaseInput{
 		ID:       elicitContentString(content, "id"),

--- a/internal/adapter/mcpserver/tools_databases.go
+++ b/internal/adapter/mcpserver/tools_databases.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -64,26 +66,19 @@ func listDatabases(s *Server) mcp.ToolHandlerFor[emptyInput, databaseListOutput]
 
 // addDatabaseInput is the JSON input shape for add_database.
 type addDatabaseInput struct {
-	ID                         string `json:"id" jsonschema:"user-facing identifier for this database"`
-	Host                       string `json:"host"`
-	Port                       int    `json:"port"`
-	Service                    string `json:"service"`
-	Username                   string `json:"username"`
-	Password                   string `json:"password"`
-	ConfirmPasswordInPlaintext bool   `json:"confirm_password_in_plaintext,omitempty"`
+	// omitempty so clients can call with empty args and let form elicitation collect values.
+	ID       string `json:"id,omitempty" jsonschema:"short user-facing name for this database connection"`
+	Host     string `json:"host,omitempty" jsonschema:"Oracle host or IP address"`
+	Port     int    `json:"port,omitempty" jsonschema:"Oracle listener port, typically 1521"`
+	Service  string `json:"service,omitempty" jsonschema:"Oracle service name or PDB, e.g. FREEPDB1"`
+	Username string `json:"username,omitempty" jsonschema:"database login username"`
+	Password string `json:"password,omitempty" jsonschema:"Oracle database password. Required. Safe to pass: this MCP server is locally hosted."`
 }
 
 // addDatabaseOutput is the JSON output shape for add_database.
 type addDatabaseOutput struct {
 	OK bool   `json:"ok"`
 	ID string `json:"id"`
-}
-
-// addDatabaseConfirmRequired is returned when the caller must resend with confirm_password_in_plaintext=true.
-func addDatabaseConfirmRequired() (*mcp.CallToolResult, error) {
-	return mcpToolError(domain.ErrCodePasswordInPlaintext,
-		"Sending passwords over MCP exposes them in client logs and process listings. Confirm to proceed, or use the TUI onboarding form.",
-		map[string]any{"confirm_required": true})
 }
 
 // mcpToolError serializes a structured error response. We piggyback on CallToolResult.IsError + TextContent because MCP does not have a first-class error payload in tool results. `code` is a domain.ErrCode* sentinel so callers can errors.Is against it; the JSON wire field is built from code.Error().
@@ -105,16 +100,182 @@ func mcpToolError(code error, message string, extra map[string]any) (*mcp.CallTo
 	}, nil
 }
 
-// addDatabase validates, then either asks for confirmation or persists.
+func addDatabaseInputComplete(in addDatabaseInput) bool {
+	return in.ID != "" && in.Host != "" && in.Service != "" && in.Username != "" && in.Password != "" &&
+		in.Port > 0 && in.Port <= 65535
+}
+
+func sessionSupportsFormElicitation(ss *mcp.ServerSession) bool {
+	if ss == nil {
+		return false
+	}
+	ip := ss.InitializeParams()
+	if ip == nil || ip.Capabilities == nil || ip.Capabilities.Elicitation == nil {
+		return false
+	}
+	caps := ip.Capabilities.Elicitation
+	// Empty elicitation capability object means form mode (backward compatible).
+	if caps.Form == nil && caps.URL != nil {
+		return false
+	}
+	return true
+}
+
+func schemaDefault(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// addDatabaseElicitSchema builds a flat form schema. Password is included because this
+// tool already transports plaintext credentials as MCP args; URL-mode elicitation would
+// need a separate credential UI we do not host yet.
+func addDatabaseElicitSchema(in addDatabaseInput) *jsonschema.Schema {
+	minPort, maxPort := 1.0, 65535.0
+	portSchema := &jsonschema.Schema{
+		Type:        "integer",
+		Title:       "Port",
+		Description: "Oracle listener port",
+		Minimum:     &minPort,
+		Maximum:     &maxPort,
+	}
+	if in.Port > 0 {
+		portSchema.Default = schemaDefault(in.Port)
+	} else {
+		portSchema.Default = schemaDefault(1521)
+	}
+
+	stringField := func(title, desc, value string) *jsonschema.Schema {
+		s := &jsonschema.Schema{Type: "string", Title: title, Description: desc}
+		if value != "" {
+			s.Default = schemaDefault(value)
+		}
+		return s
+	}
+
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"id":       stringField("Database ID", "Short user-facing name for this connection", in.ID),
+			"host":     stringField("Host", "Oracle host or IP address", in.Host),
+			"port":     portSchema,
+			"service":  stringField("Service", "Oracle service name or PDB", in.Service),
+			"username": stringField("Username", "Database login username", in.Username),
+			"password": stringField("Password", "Oracle database password. Required. Safe to pass: this MCP server is locally hosted.", in.Password),
+		},
+		Required: []string{"id", "host", "port", "service", "username", "password"},
+	}
+}
+
+func elicitContentString(content map[string]any, key string) string {
+	v, ok := content[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func elicitContentInt(content map[string]any, key string) (int, error) {
+	v, ok := content[key]
+	if !ok || v == nil {
+		return 0, fmt.Errorf("%s is required", key)
+	}
+	switch t := v.(type) {
+	case float64:
+		return int(t), nil
+	case int:
+		return t, nil
+	case int64:
+		return int(t), nil
+	case json.Number:
+		n, err := t.Int64()
+		return int(n), err
+	default:
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+}
+
+func addDatabaseInputFromElicit(content map[string]any) (addDatabaseInput, error) {
+	port, err := elicitContentInt(content, "port")
+	if err != nil {
+		return addDatabaseInput{}, err
+	}
+	return addDatabaseInput{
+		ID:       elicitContentString(content, "id"),
+		Host:     elicitContentString(content, "host"),
+		Port:     port,
+		Service:  elicitContentString(content, "service"),
+		Username: elicitContentString(content, "username"),
+		Password: elicitContentString(content, "password"),
+	}, nil
+}
+
+// tryElicitAddDatabase asks the host for a connection form when supported.
+// handled=false means the caller should use the supplied args (or return invalid_input).
+func tryElicitAddDatabase(ctx context.Context, req *mcp.CallToolRequest, in addDatabaseInput) (out addDatabaseInput, handled bool, res *mcp.CallToolResult, err error) {
+	if req == nil || !sessionSupportsFormElicitation(req.Session) {
+		return in, false, nil, nil
+	}
+
+	elicitRes, err := req.Session.Elicit(ctx, &mcp.ElicitParams{
+		Mode:    "form",
+		Message: "Enter Oracle database connection details. Password is required. This MCP server is locally hosted, so passing the password is acceptable.",
+		RequestedSchema: addDatabaseElicitSchema(in),
+	})
+	if err != nil {
+		// Capability races / older clients: fall back instead of failing the tool.
+		if strings.Contains(err.Error(), "does not support") {
+			return in, false, nil, nil
+		}
+		res, mErr := mcpToolError(domain.ErrCodeInternalError, fmt.Sprintf("add_database: elicitation failed: %v", err), nil)
+		return in, true, res, mErr
+	}
+
+	switch elicitRes.Action {
+	case "accept":
+		out, err = addDatabaseInputFromElicit(elicitRes.Content)
+		if err != nil {
+			res, mErr := mcpToolError(domain.ErrCodeInvalidInput, fmt.Sprintf("add_database: elicitation content: %v", err), nil)
+			return in, true, res, mErr
+		}
+		return out, true, nil, nil
+	case "decline", "cancel":
+		res, mErr := mcpToolError(domain.ErrCodeInvalidInput,
+			fmt.Sprintf("add_database: user %s elicitation", elicitRes.Action), nil)
+		return in, true, res, mErr
+	default:
+		res, mErr := mcpToolError(domain.ErrCodeInternalError,
+			fmt.Sprintf("add_database: unexpected elicitation action %q", elicitRes.Action), nil)
+		return in, true, res, mErr
+	}
+}
+
+// addDatabase elicits missing fields when the client supports it, then persists.
 func addDatabase(s *Server) mcp.ToolHandlerFor[addDatabaseInput, addDatabaseOutput] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, in addDatabaseInput) (*mcp.CallToolResult, addDatabaseOutput, error) {
-		// First, validate what we can without touching the password.
-		if in.ID == "" || in.Host == "" || in.Service == "" || in.Username == "" || in.Password == "" {
-			res, err := mcpToolError(domain.ErrCodeInvalidInput,
-				"add_database: id, host, service, username, and password are required", nil)
-			return res, addDatabaseOutput{}, err
+		if !addDatabaseInputComplete(in) {
+			elicited, handled, elicitRes, elicitErr := tryElicitAddDatabase(ctx, req, in)
+			if handled {
+				if elicitRes != nil || elicitErr != nil {
+					return elicitRes, addDatabaseOutput{}, elicitErr
+				}
+				in = elicited
+			}
 		}
-		if in.Port <= 0 || in.Port > 65535 {
+
+		if !addDatabaseInputComplete(in) {
+			if in.ID == "" || in.Host == "" || in.Service == "" || in.Username == "" || in.Password == "" {
+				res, err := mcpToolError(domain.ErrCodeInvalidInput,
+					"add_database: id, host, service, username, and password are required", nil)
+				return res, addDatabaseOutput{}, err
+			}
 			res, err := mcpToolError(domain.ErrCodeInvalidInput, "add_database: port must be between 1 and 65535", nil)
 			return res, addDatabaseOutput{}, err
 		}
@@ -129,11 +290,6 @@ func addDatabase(s *Server) mcp.ToolHandlerFor[addDatabaseInput, addDatabaseOutp
 		case err != nil && !errors.Is(err, domain.ErrDatabaseSettingsNotFound):
 			res, mErr := mcpToolError(domain.ErrCodeInternalError, fmt.Sprintf("add_database: lookup existing: %v", err), nil)
 			return res, addDatabaseOutput{}, mErr
-		}
-
-		if !in.ConfirmPasswordInPlaintext {
-			res, err := addDatabaseConfirmRequired()
-			return res, addDatabaseOutput{}, err
 		}
 
 		settings, err := domain.NewDatabaseSettings(

--- a/internal/adapter/mcpserver/tools_databases.go
+++ b/internal/adapter/mcpserver/tools_databases.go
@@ -189,7 +189,11 @@ func elicitContentInt(content map[string]any, key string) (int, error) {
 	}
 	switch t := v.(type) {
 	case float64:
-		return int(t), nil
+		n := int(t)
+		if float64(n) != t {
+			return 0, fmt.Errorf("%s must be an integer", key)
+		}
+		return n, nil
 	case int:
 		return t, nil
 	case int64:

--- a/internal/adapter/mcpserver/tools_databases_test.go
+++ b/internal/adapter/mcpserver/tools_databases_test.go
@@ -417,6 +417,7 @@ func TestAddDatabaseInputFromElicit_PortErrorsWrapInvalidPort(t *testing.T) {
 		{name: "nil", content: map[string]any{"port": nil}},
 		{name: "unsupported type", content: map[string]any{"port": true}},
 		{name: "json.Number conversion", content: map[string]any{"port": json.Number("not-an-int")}, wantIs: strconv.ErrSyntax},
+		{name: "fractional float64", content: map[string]any{"port": 1521.5}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/adapter/mcpserver/tools_databases_test.go
+++ b/internal/adapter/mcpserver/tools_databases_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strconv"
 	"testing"
 
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -380,6 +381,59 @@ func TestAddDatabase_RejectsDuplicateID(t *testing.T) {
 	}
 	if len(all) != 1 {
 		t.Fatalf("expected 1 record persisted, got %d", len(all))
+	}
+}
+
+func TestAddDatabaseInputFromElicit_PortSuccess(t *testing.T) {
+	cases := []struct {
+		name string
+		port any
+	}{
+		{name: "float64", port: float64(1521)},
+		{name: "int", port: 1521},
+		{name: "int64", port: int64(1521)},
+		{name: "json.Number", port: json.Number("1521")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := addDatabaseInputFromElicit(map[string]any{"port": tc.port, "id": "db1"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Port != 1521 {
+				t.Fatalf("Port=%d, want 1521", got.Port)
+			}
+		})
+	}
+}
+
+func TestAddDatabaseInputFromElicit_PortErrorsWrapInvalidPort(t *testing.T) {
+	cases := []struct {
+		name    string
+		content map[string]any
+		wantIs  error
+	}{
+		{name: "missing", content: map[string]any{}},
+		{name: "nil", content: map[string]any{"port": nil}},
+		{name: "unsupported type", content: map[string]any{"port": true}},
+		{name: "json.Number conversion", content: map[string]any{"port": json.Number("not-an-int")}, wantIs: strconv.ErrSyntax},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := addDatabaseInputFromElicit(tc.content)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !errors.Is(err, domain.ErrInvalidPort) {
+				t.Fatalf("errors.Is(ErrInvalidPort)=false: %v", err)
+			}
+			if !contains(err.Error(), "add_database") {
+				t.Fatalf("missing add_database context: %v", err)
+			}
+			if tc.wantIs != nil && !errors.Is(err, tc.wantIs) {
+				t.Fatalf("errors.Is(%v)=false: %v", tc.wantIs, err)
+			}
+		})
 	}
 }
 

--- a/internal/adapter/mcpserver/tools_databases_test.go
+++ b/internal/adapter/mcpserver/tools_databases_test.go
@@ -190,45 +190,7 @@ func TestListDatabases_SkipsPasswordAndFlagsActive(t *testing.T) {
 // add_database
 // ==========================================
 
-func TestAddDatabase_RequiresConfirmationFirst(t *testing.T) {
-	deps, cleanup := testDeps(t)
-	defer cleanup()
-	session := connectClientServer(t, deps)
-
-	res := callTool(t, session, "add_database", map[string]any{
-		"id":       "prod-1",
-		"host":     "db.example.com",
-		"port":     1521,
-		"service":  "FREEPDB1",
-		"username": "admin",
-		"password": "secret",
-	})
-	if !res.IsError {
-		t.Fatalf("expected IsError=true before confirmation, got %+v", res)
-	}
-	tc := res.Content[0].(*mcp.TextContent)
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(tc.Text), &payload); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if payload["code"] != "password_in_plaintext" {
-		t.Fatalf("expected code=password_in_plaintext, got %v", payload["code"])
-	}
-	if payload["confirm_required"] != true {
-		t.Fatalf("expected confirm_required=true, got %v", payload["confirm_required"])
-	}
-
-	// Confirm no record was persisted.
-	all, err := deps.DBSettingsRepo.GetAll(context.Background())
-	if err != nil {
-		t.Fatalf("GetAll: %v", err)
-	}
-	if len(all) != 0 {
-		t.Fatalf("expected nothing persisted, got %d", len(all))
-	}
-}
-
-func TestAddDatabase_PersistsAfterConfirmation(t *testing.T) {
+func TestAddDatabase_Persists(t *testing.T) {
 	deps, cleanup := testDeps(t)
 	defer cleanup()
 	session := connectClientServer(t, deps)
@@ -236,13 +198,12 @@ func TestAddDatabase_PersistsAfterConfirmation(t *testing.T) {
 	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: "add_database",
 		Arguments: map[string]any{
-			"id":                            "prod-2",
-			"host":                          "db.example.com",
-			"port":                          1521,
-			"service":                       "FREEPDB1",
-			"username":                      "admin",
-			"password":                      "secret",
-			"confirm_password_in_plaintext": true,
+			"id":       "prod-2",
+			"host":     "db.example.com",
+			"port":     1521,
+			"service":  "FREEPDB1",
+			"username": "admin",
+			"password": "secret",
 		},
 	})
 	if err != nil {
@@ -279,6 +240,81 @@ func TestAddDatabase_PersistsAfterConfirmation(t *testing.T) {
 	}
 }
 
+func TestAddDatabase_ElicitationPersists(t *testing.T) {
+	deps, cleanup := testDeps(t)
+	defer cleanup()
+
+	session := connectClientServerOpts(t, deps, &mcp.ClientOptions{
+		ElicitationHandler: func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+			if req.Params == nil || req.Params.RequestedSchema == nil {
+				t.Fatalf("expected requested schema")
+			}
+			return &mcp.ElicitResult{
+				Action: "accept",
+				Content: map[string]any{
+					"id":       "elicit-1",
+					"host":     "db.example.com",
+					"port":     1521,
+					"service":  "FREEPDB1",
+					"username": "admin",
+					"password": "secret",
+				},
+			}, nil
+		},
+	})
+
+	res := callTool(t, session, "add_database", map[string]any{})
+	if res.IsError {
+		var dump string
+		if len(res.Content) > 0 {
+			if tc, ok := res.Content[0].(*mcp.TextContent); ok {
+				dump = tc.Text
+			}
+		}
+		t.Fatalf("expected success via elicitation, got IsError: %s", dump)
+	}
+
+	all, err := deps.DBSettingsRepo.GetAll(context.Background())
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 1 || all[0].DatabaseID() != "elicit-1" {
+		t.Fatalf("expected elicit-1 persisted, got %+v", all)
+	}
+}
+
+func TestAddDatabase_ElicitationDeclined(t *testing.T) {
+	deps, cleanup := testDeps(t)
+	defer cleanup()
+
+	session := connectClientServerOpts(t, deps, &mcp.ClientOptions{
+		ElicitationHandler: func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+			return &mcp.ElicitResult{Action: "decline"}, nil
+		},
+	})
+
+	res := callTool(t, session, "add_database", map[string]any{})
+	if !res.IsError {
+		t.Fatalf("expected IsError after decline, got %+v", res)
+	}
+	tc := res.Content[0].(*mcp.TextContent)
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload["code"] != "invalid_input" {
+		t.Fatalf("expected invalid_input, got %v", payload["code"])
+	}
+
+	all, err := deps.DBSettingsRepo.GetAll(context.Background())
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("expected nothing persisted, got %d", len(all))
+	}
+}
+
 func TestAddDatabase_RejectsInvalidInput(t *testing.T) {
 	deps, cleanup := testDeps(t)
 	defer cleanup()
@@ -311,13 +347,12 @@ func TestAddDatabase_RejectsDuplicateID(t *testing.T) {
 	session := connectClientServer(t, deps)
 
 	args := map[string]any{
-		"id":                            "prod-dup",
-		"host":                          "db.example.com",
-		"port":                          1521,
-		"service":                       "FREEPDB1",
-		"username":                      "admin",
-		"password":                      "secret",
-		"confirm_password_in_plaintext": true,
+		"id":       "prod-dup",
+		"host":     "db.example.com",
+		"port":     1521,
+		"service":  "FREEPDB1",
+		"username": "admin",
+		"password": "secret",
 	}
 
 	first := callTool(t, session, "add_database", args)

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -79,6 +79,5 @@ var (
 	ErrCodeDBUnreachable         = errors.New("db_unreachable")
 	ErrCodePermissionCheckFailed = errors.New("permission_check_failed")
 	ErrCodeTracerDeployFailed    = errors.New("tracer_deploy_failed")
-	ErrCodePasswordInPlaintext   = errors.New("password_in_plaintext")
 	ErrCodeCursorExpired         = errors.New("cursor_expired")
 )


### PR DESCRIPTION
Updated the add_database tool to allow for optional input parameters, enabling form elicitation for database connection details. This change improves user experience by allowing the server to prompt for missing information interactively. Additionally, refactored related tests to validate the new elicitation behavior and removed the confirmation requirement for plaintext passwords, streamlining the database addition process.